### PR TITLE
plugins/rink: Let the user disable rink connecting to the internet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,8 @@ dependencies = [
  "anyrun-plugin",
  "reqwest",
  "rink-core",
+ "ron",
+ "serde",
 ]
 
 [[package]]

--- a/plugins/rink/Cargo.toml
+++ b/plugins/rink/Cargo.toml
@@ -11,5 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyrun-plugin = { path = "../../anyrun-plugin" }
 abi_stable = "0.11.1"
-rink-core = "0.6"
 reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+rink-core = "0.6"
+ron = "0.8.0"
+serde = { version = "1.0.159", features = ["derive"] }

--- a/plugins/rink/README.md
+++ b/plugins/rink/README.md
@@ -5,3 +5,13 @@ A simple calculator plugin powered by [Rink](https://github.com/tiffany352/rink-
 ## Usage
 
 Just type in your calculations/unit conversions.
+
+## Configuration
+
+```ron
+// <Anyrun config dir>/rink.ron
+Config(
+  // Pull currency conversions from https://rinkcalc.app/data/currency.json
+  pull_currencies: true,
+)
+```

--- a/plugins/rink/src/lib.rs
+++ b/plugins/rink/src/lib.rs
@@ -1,35 +1,67 @@
 use abi_stable::std_types::{ROption, RString, RVec};
 use anyrun_plugin::*;
 use rink_core::{ast, date, gnu_units, CURRENCY_FILE};
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize)]
+pub struct Config {
+    pull_currencies: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            pull_currencies: true,
+        }
+    }
+}
+
+pub struct State {
+    config: Config,
+    ctx: rink_core::Context,
+}
 
 #[init]
-fn init(_config_dir: RString) -> rink_core::Context {
+fn init(config_dir: RString) -> State {
+
+    let config: Config = match fs::read_to_string(format!("{}/rink.ron", config_dir)) {
+        Ok(content) => ron::from_str(&content).unwrap_or_else(|why| {
+            eprintln!("Error parsing rink plugin config: {}", why);
+            Config::default()
+        }),
+        Err(why) => {
+            eprintln!("Error reading rink plugin config: {}", why);
+            Config::default()
+        }
+    };
+
     let mut ctx = rink_core::Context::new();
 
     let units = gnu_units::parse_str(rink_core::DEFAULT_FILE.unwrap());
     let dates = date::parse_datefile(rink_core::DATES_FILE);
 
-    let mut currency_defs = Vec::new();
-
-    match reqwest::blocking::get("https://rinkcalc.app/data/currency.json") {
-        Ok(response) => match response.json::<ast::Defs>() {
-            Ok(mut live_defs) => {
-                currency_defs.append(&mut live_defs.defs);
-            }
-            Err(why) => println!("Error parsing currency json: {}", why),
-        },
-        Err(why) => println!("Error fetching up-to-date currency conversions: {}", why),
+    if config.pull_currencies {
+        let mut currency_defs = Vec::new();
+        match reqwest::blocking::get("https://rinkcalc.app/data/currency.json") {
+            Ok(response) => match response.json::<ast::Defs>() {
+                Ok(mut live_defs) => {
+                    currency_defs.append(&mut live_defs.defs);
+                }
+                Err(why) => println!("Error parsing currency json: {}", why),
+            },
+            Err(why) => println!("Error fetching up-to-date currency conversions: {}", why),
+        }
+        currency_defs.append(&mut gnu_units::parse_str(CURRENCY_FILE).defs);
+        ctx.load(ast::Defs {
+            defs: currency_defs,
+        });
     }
 
-    currency_defs.append(&mut gnu_units::parse_str(CURRENCY_FILE).defs);
-
     ctx.load(units);
-    ctx.load(ast::Defs {
-        defs: currency_defs,
-    });
     ctx.load_dates(dates);
 
-    ctx
+    State { config, ctx }
 }
 
 #[info]
@@ -41,8 +73,8 @@ fn info() -> PluginInfo {
 }
 
 #[get_matches]
-fn get_matches(input: RString, ctx: &mut rink_core::Context) -> RVec<Match> {
-    match rink_core::one_line(ctx, &input) {
+fn get_matches(input: RString, state: &mut State) -> RVec<Match> {
+    match rink_core::one_line(&mut state.ctx, &input) {
         Ok(result) => {
             let (title, desc) = parse_result(result);
             vec![Match {


### PR DESCRIPTION
This PR adds configuration to the rink plugins so that users can disable pulling current currency conversion upon plugin startup.

This stops the rink plugin from connecting to the internet upon startup, as a result the plugin initializes much faster.

A downside is that rink no longer offers currency conversions.

The feature is opt-in, nothing should change as long as the user doesn't specifically disable the pulling of currencies for rink.