### PR TITLE
Use `nix.settings.extra-*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,12 @@ You might also want to use the binary cache to avoid building locally.
 ```nix
 nix.settings = {
     builders-use-substitutes = true;
-    # substituters to use
-    substituters = [
+    # extra substituters to add
+    extra-substituters = [
         "https://anyrun.cachix.org"
     ];
 
-    trusted-public-keys = [
+    extra-trusted-public-keys = [
         "anyrun.cachix.org-1:pqBobmOjI7nKlsUMV25u9QHa9btJK65/C8vnO3p346s="
     ];
 };


### PR DESCRIPTION
Though mostly undocumented, setting `nix.settings.substituters` overwrites any previous entries, including the default nixpkgs binary cache. Using `nix.settings.extra-substituters` appends to the list instead, independent of any nixpkgs or NixOS module logic.
See the [nix manual entry](https://nixos.org/manual/nix/stable/command-ref/conf-file.html?highlight=extra-substituters#file-format)