### PR TITLE
Nix: Add overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,31 @@ You can use the flake:
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    anyrun.url = "github:Kirottu/anyrun";
+    anyrun.url = "github:anyrun-org/anyrun";
     anyrun.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, anyrun }: let
   in {
-    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+    # Variant 1: Add the overlay
+    nixosConfigurations.HOSTNAME1 = nixpkgs.lib.nixosSystem {
+      # ...
+      modules = [({pkgs, ... }: {
+        nixpkgs.overlays = [
+          # ...
+          anyrun.overlays.default
+        ];
+
+        environment.systemPackages = [ pkgs.anyrun ];
+        # Overlay also adds: pkgs.anyrun-with-all-plugins
+        #                    pkgs.anyrunPlugins.<name>
+
+        # ...
+      })];
+    };
+
+    # Variant 2: Directly access the package
+    nixosConfigurations.HOSTNAME2 = nixpkgs.lib.nixosSystem {
       # ...
 
       environment.systemPackages = [ anyrun.packages.${system}.anyrun ];

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,11 @@
           anyrun = import ./nix/hm-module.nix inputs.self;
           default = anyrun;
         };
+
+        overlays = rec {
+          anyrun = import ./nix/overlay.nix inputs.self;
+          default = anyrun;
+        };
       };
     };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,21 @@
+flake: final: prev: let
+  anyrunPkgs = flake.packages.${final.system};
+in {
+  inherit (anyrunPkgs) anyrun anyrun-with-all-plugins;
+
+  anyrunPlugins = {
+    inherit
+      (anyrunPkgs)
+      applications
+      dictionary
+      kidex
+      randr
+      rink
+      shell
+      stdin
+      symbols
+      translate
+      websearch
+      ;
+  };
+}


### PR DESCRIPTION
Hi, I just discovered anyrun a few days ago. I noticed that your flake doesn't provide an overlay with the packages.

Overlays make it possible to "merge" some packages into the main nixpkgs channel when writing your configuration, so it's easier to access them. By using overlays, the files that use anyrun packages won't need to do `inputs.anyrun.packages.${system}.<name>` but rather `pkgs.<name>` (or pkgs.anyrunPlugins.<name>`).

In this PR I added a nixpkgs overlay for the packages from the anyrun flake. I chose to put the plugins in a nested attribute set to avoid conflicts and make it easier to list them, e.g. in nix repl.
I also updated the sample in README.md (and the git repo reference).

Let me know if I should change something :)