### PR TITLE
nix: generate overlay from exposed packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
 
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [flake-parts.flakeModules.easyOverlay];
       systems = ["x86_64-linux" "aarch64-linux"];
 
       perSystem = {
@@ -105,6 +106,9 @@
             name = "websearch";
           };
         };
+
+        # Set up an overlay from packages exposed by this flake
+        overlayAttrs = config.packages;
       };
 
       flake = _: rec {


### PR DESCRIPTION
Uses flake-parts' internal easyOverlay module to generate an overlay of packages for those prefer overlays for some reason. I'd add a warning to the code, but it's a valid use case regardless of how bad of an idea overlays are.

Supersedes #159 