### PR TITLE
Fix numpad keys not working

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -484,7 +484,12 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
                 Inhibit(true)
             }
             // Handle selections
-            constants::Down | constants::Tab | constants::Up => {
+            constants::Down
+            | constants::Tab
+            | constants::Up
+            | constants::KP_Down
+            | constants::KP_Tab
+            | constants::KP_Up => {
                 // Combine all of the matches into a `Vec` to allow for easier handling of the selection
                 let combined_matches = runtime_data_clone
                     .borrow()
@@ -511,10 +516,13 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
                             // If nothing is selected select either the top or bottom match based on the input
                             if !combined_matches.is_empty() {
                                 match event.keyval() {
-                                    constants::Down | constants::Tab => combined_matches[0]
+                                    constants::Down
+                                    | constants::Tab
+                                    | constants::KP_Down
+                                    | constants::KP_Tab => combined_matches[0]
                                         .1
                                         .select_row(Some(&combined_matches[0].0)),
-                                    constants::Up => {
+                                    constants::Up | constants::KP_Up => {
                                         combined_matches[combined_matches.len() - 1].1.select_row(
                                             Some(&combined_matches[combined_matches.len() - 1].0),
                                         )
@@ -537,7 +545,7 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
 
                 // Move the selection based on the input, loops from top to bottom and vice versa
                 match event.keyval() {
-                    constants::Down | constants::Tab => {
+                    constants::Down | constants::Tab | constants::KP_Down | constants::KP_Tab => {
                         if index < combined_matches.len() - 1 {
                             combined_matches[index + 1]
                                 .1
@@ -548,7 +556,7 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
                                 .select_row(Some(&combined_matches[0].0));
                         }
                     }
-                    constants::Up => {
+                    constants::Up | constants::KP_Up => {
                         if index > 0 {
                             combined_matches[index - 1]
                                 .1
@@ -565,7 +573,7 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
                 Inhibit(true)
             }
             // Handle when the selected match is "activated"
-            constants::Return => {
+            constants::Return | constants::KP_Enter => {
                 let mut _runtime_data_clone = runtime_data_clone.borrow_mut();
 
                 let (selected_match, plugin_view) = match _runtime_data_clone


### PR DESCRIPTION
There is a bug/feature in GTK that makes handling of numpad keys separate from "regular" keys (e.g. [KP_Enter](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdkkeysyms.h#L101) != Return). This behavior has been reported for [GTK3](https://gitlab.gnome.org/GNOME/gtk/-/issues/3868) and for [GTK4](https://gitlab.gnome.org/GNOME/gtk/-/issues/6660), so this may be fixed in the future. For now, these keycodes should be handled manually.