### PR TITLE
Add browser option to websearch plugin

### DIFF
--- a/plugins/websearch/README.md
+++ b/plugins/websearch/README.md
@@ -13,6 +13,7 @@ Default config
 ```ron
 Config(
   prefix: "?",
+  browser: "xdg-open",
   // Options: Google, Ecosia, Bing, DuckDuckGo, Custom
   //
   // Custom engines can be defined as such:

--- a/plugins/websearch/src/lib.rs
+++ b/plugins/websearch/src/lib.rs
@@ -40,6 +40,7 @@ impl fmt::Display for Engine {
 #[derive(Deserialize, Debug)]
 struct Config {
     prefix: String,
+    browser: String,
     engines: Vec<Engine>,
 }
 
@@ -47,6 +48,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             prefix: "?".to_string(),
+            browser: "xdg-open".to_string(),
             engines: vec![Engine::Google],
         }
     }
@@ -95,7 +97,8 @@ fn handler(selection: Match, config: &Config) -> HandleResult {
     if let Err(why) = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "xdg-open https://{}",
+            "{} https://{}",
+            &config.browser,
             engine
                 .value()
                 .replace("{}", &encode(&selection.title.to_string()))


### PR DESCRIPTION
This allows you to choose a custom browser.

**Examples**:
- You have both Firefox and Chrome. Firefox is your default but you want websearch to use Chrome:
  ```ron
  Config(
      browser: "chrome",
  )
  ```
- You want to pass custom flags to your browser:
  ```ron
  Config(
      browser: "firefox --new-window",
  )
  ```

**Note**: currently, if the `browser` option is omitted from your config, the plugin does not appear. This bug wasn't caused by this PR: omitting `prefix` breaks it too; it also only seems to happen for this one plugin. I am going to try to fix it and submit another PR if I'm successful (or an issue if I'm not).