### PR TITLE
Support KP_Enter as selection key

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -565,7 +565,7 @@ fn activate(app: &gtk::Application, runtime_data: Rc<RefCell<RuntimeData>>) {
                 Inhibit(true)
             }
             // Handle when the selected match is "activated"
-            constants::Return => {
+            constants::Return | constants::KP_Enter => {
                 let mut _runtime_data_clone = runtime_data_clone.borrow_mut();
 
                 let (selected_match, plugin_view) = match _runtime_data_clone


### PR DESCRIPTION
This adds selection/action support for the numpad enter key.

This is because previously only the return key worked but that one is broken on my keyboard.
So I added the numpad key as well because why not. ¯\\\_(ツ)_/¯