### PR TITLE
feat: Add usage statistics for applications to improve search results

### DIFF
--- a/examples/applications.ron
+++ b/examples/applications.ron
@@ -1,0 +1,16 @@
+Config(
+  // Limit amount of entries shown by the applications plugin (default: 5)
+  max_entries: 5,
+  // Whether to evaluate desktop actions as well as desktop applications (default: false)
+  desktop_actions: false,
+  // Whether to use a specific terminal or just the first terminal available (default: None)
+  terminal: None,
+  // Whether or not to put more often used applications higher in the search rankings (default: true)
+  use_usage_statistics: true,
+  // How much score to add for every usage of an application (default: 50)
+  // Each matching letter is 25 points
+  usage_score_multiplier: 50,
+  // Maximum amount of usages to count (default: 10)
+  // This is to limit the added score, so often used apps don't get too big of a boost
+  max_counted_usages: 10,
+)

--- a/plugins/applications/src/execution_stats.rs
+++ b/plugins/applications/src/execution_stats.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::Config;
+use crate::scrubber::DesktopEntry;
+
+pub(crate) struct ExecutionStats {
+    weight_map: Arc<Mutex<HashMap<String, i64>>>,
+    max_weight: i64,
+    execution_statistics_path: String,
+}
+
+impl ExecutionStats {
+    pub(crate) fn from_file_or_default(execution_statistics_path: &str, config: &Config) -> Self {
+        let execution_statistics: HashMap<String, i64> = fs::read_to_string(execution_statistics_path)
+            .map_err(|error| format!("Error parsing applications plugin config: {}", error))
+            .and_then(|content: String| ron::from_str(&content)
+                .map_err(|error| format!("Error reading applications plugin config: {}", error)))
+            .unwrap_or_else(|error_message| {
+                format!("{}", error_message);
+                HashMap::new()
+            });
+
+        ExecutionStats {
+            weight_map: Arc::new(Mutex::new(execution_statistics)),
+            max_weight: config.max_counted_usages,
+            execution_statistics_path: execution_statistics_path.to_owned(),
+        }
+    }
+
+    pub(crate) fn save(&self) -> Result<(), String> {
+        let path = Path::new(&self.execution_statistics_path);
+        if let Some(containing_folder) = path.parent() {
+            if !containing_folder.exists() {
+                fs::create_dir_all(containing_folder)
+                    .map_err(|error| format!("Error creating containing folder for usage statistics: {:?}", error))?;
+            }
+            let mut file = OpenOptions::new().create(true).write(true).truncate(true).open(path)
+                .map_err(|error| format!("Error creating data file for usage statistics: {:?}", error))?;
+            let weight_map = self.weight_map.lock()
+                .map_err(|error| format!("Error locking file for usage statistics: {:?}", error))?;
+            let serialized_data = ron::to_string(&*weight_map)
+                .map_err(|error| format!("Error serializing usage statistics: {:?}", error))?;
+            file.write_all(serialized_data.as_bytes())
+                .map_err(|error| format!("Error writing data file for usage statistics: {:?}", error))
+        } else {
+            Err(format!("Error getting parent folder of: {:?}", path))
+        }
+    }
+
+    pub(crate) fn register_usage(&self, application: &DesktopEntry) {
+        {
+            let mut guard = self.weight_map.lock().unwrap();
+            if let Some(count) = guard.get_mut(&application.exec) {
+                *count += 1;
+            } else {
+                guard.insert(application.exec.clone(), 1);
+            }
+        }
+        if let Err(error_message) = self.save() {
+            eprintln!("{}", error_message);
+        }
+    }
+
+    pub(crate) fn get_weight(&self, application: &DesktopEntry) -> i64 {
+        let weight = *self.weight_map.lock().unwrap().get(&application.exec).unwrap_or(&0);
+
+        if weight < self.max_weight {
+            weight
+        } else {
+            self.max_weight
+        }
+    }
+}


### PR DESCRIPTION
I added a small module, which allows anyrun to keep track of how often an entry has been launched.
Anyrun can then use these statistics to improve the search ranking of these applications.

There the applications plugin has gained the following configuration options:

    use_usage_statistics: bool
    /// Whether to put more often used applications higher in the search rankings (default: true)

    usage_score_multiplier: i64
    /// How much score to add for every usage of an application (default: 50)
    /// As a reference: Each matching letter is 25 points


    max_counted_usages: i64
    /// Maximum amount of usages to count (default: 10)
    /// This is to limit the added score, so often used apps don't get too big of a boost


An amended configurations file has been provided that mirrors the default config, just like the `config.ron` does for the main application.

Since I see no downside to this, I have chosen to enable this feature by default.

Please let me know, if you'd like me to make any changes.