### PR TITLE
plugins/applications: add preprocess_exec_script option

### DIFF
--- a/plugins/applications/README.md
+++ b/plugins/applications/README.md
@@ -15,7 +15,13 @@ Simply search for the application you wish to launch.
 Config(
   // Also show the Desktop Actions defined in the desktop files, e.g. "New Window" from LibreWolf
   desktop_actions: true,
-  max_entries: 5, 
+
+  max_entries: 5,
+
+  // A command to preprocess the command from the desktop file. The commands should take arguments in this order:
+  // command_name <term|no-term> <command>
+  preprocess_exec_script: Some("/home/user/.local/share/anyrun/preprocess_application_command.sh")
+
   // The terminal used for running terminal based desktop entries, if left as `None` a static list of terminals is used
   // to determine what terminal to use.
   terminal: Some(Terminal(


### PR DESCRIPTION
This option lets you add a script that can transform the command of a desktop option (in my case to prepend `uwsm app --`), or otherwise cause side effects like collecting statistics or running notify-send.