### PR TITLE
Applications: Properly parse desktop exec keys and stop shelling out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "fuzzy-matcher",
  "ron 0.8.1",
  "serde",
+ "shell-words",
  "sublime_fuzzy",
 ]
 
@@ -2564,6 +2565,12 @@ dependencies = [
  "ron 0.8.1",
  "serde",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/plugins/applications/Cargo.toml
+++ b/plugins/applications/Cargo.toml
@@ -14,4 +14,5 @@ anyrun-plugin = { path = "../../anyrun-plugin" }
 fuzzy-matcher = "0.3.7"
 ron           = "0.8.0"
 serde         = { features = [ "derive" ], version = "1.0.228" }
+shell-words = "1.1.1"
 sublime_fuzzy = "0.7.0"

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -55,7 +55,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
         })
         .unwrap();
 
-    let (command, argv) = match lower_exec(&entry.exec) {
+    let (command, argv) = match lower_exec(&entry) {
         Ok((command, argv)) => (command, argv),
         Err(error) => {
             eprintln!("[applications] Unable to parse the exec key `{}`: {}", &entry.exec, error.0);

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -352,10 +352,15 @@ fn get_fieldcode(code: char, entry: &DesktopEntry, arg: &str) -> Result<String, 
                 return Err(
                     ExecKeyError(
                         format!(
-                            "Encountered field code %i in argument {} with other other contents, %i must stand alone.", arg)
+                            "Encountered field code %i in argument {} with other contents, %i must stand alone.", arg)
                     ))
             }
-            format!("--icon {}", entry.icon.clone())
+            let icon = entry.icon.clone();
+            if icon.is_empty() {
+                "".to_owned()
+            } else {
+                format!("--icon {}", entry.icon.clone())
+            }
         },
         c => panic!("Function called with unimplemented field code {}!", c)
     };
@@ -430,7 +435,7 @@ pub(crate) fn lower_exec(entry: &DesktopEntry) -> Result<(String, Vec<String>), 
             .into_iter()
             .map(|arg| expand_exec_fieldcodes(&entry, arg.clone()))
             .collect::<Result<Vec<_>,_>>()?;
-        let argv_stripped = argv_fieldcodes.into_iter().filter(|arg| arg.is_empty()).collect();
+        let argv_stripped = argv_fieldcodes.into_iter().filter(|arg| !arg.is_empty()).collect();
         return Ok((command.clone(), argv_stripped));
     } else {
         return Err(ExecKeyError("Empty exec key!".to_string()));


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html describes how commands and their arguments are stored in the exec key. As the exec key is a string type as defined in
https://specifications.freedesktop.org/desktop-entry-spec/latest/value-types.html escapes code for certain characters have to be respected. After this there are rules which characters necessitate a quoted string and which characters need to be escaped in a quoted string. To use the exec key for executing we then need to unescape these characters and can collect the args in a vector. This enables us to stop shelling out when executing desktop files and instead call `Command` directly with the specified program and arguments.