### PR TITLE
plugins/applications: Sort entries alphabetically to ensure deterministic ordering

### DIFF
--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -210,7 +210,8 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
         })
         .collect::<Vec<_>>();
 
-    entries.sort_by(|a, b| b.2.cmp(&a.2));
+    entries.sort_by(|a, b| b.2.cmp(&a.2)
+        .then(a.0.name.cmp(&b.0.name)));
 
     entries.truncate(state.config.max_entries);
     entries


### PR DESCRIPTION
Currently, the order of entries is partially random when multiple entries have the same score.

This is an issue when trying to open applications such as LibreOffice, which comes with multiple desktop entries (LibreOffice, LibreOffice Writer, LibreOffice Draw, LibreOffice Impress...). The "LibreOffice" entry may be completely inaccessible when just typing "LibreOffice" since the list is by default truncated to 5 entries and the entry may be preceded by more than 5 other entries.

The change in this commit sorts the entries alphabetically when they have the same score, ensuring that shorter entries are always listed first. Therefore, when typing "LibreOffice," the list always begins with "LibreOffice," "LibreOffice Base," "LibreOffice Calc"...
