### PR TITLE
Fix Websearch

### DIFF
--- a/plugins/websearch/src/lib.rs
+++ b/plugins/websearch/src/lib.rs
@@ -95,7 +95,7 @@ fn handler(selection: Match, config: &Config) -> HandleResult {
     if let Err(why) = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "xdg-open https://{}",
+            "xdg-open \"https://{}\"",
             engine
                 .value()
                 .replace("{}", &encode(&selection.title.to_string()))


### PR DESCRIPTION
fix websearch not searching properly due to missing double quotes