### PR TITLE
flake: enable the nix-run plugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,7 @@
           applications = mkPlugin "applications";
           dictionary = mkPlugin "dictionary";
           kidex = mkPlugin "kidex";
+          nix-run = mkPlugin "nix-run";
           randr = mkPlugin "randr";
           rink = mkPlugin "rink";
           shell = mkPlugin "shell";


### PR DESCRIPTION
Small change, I noticed that this plugin was added and I couldn't use it in my flake. Really cool plugin by the way!