### PR TITLE
nix/hm: add keybinds and extraLines options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,36 @@ You may use it in your system like this:
 }
 ```
 
+Alternatively, you may use the module from this repository's flake to keep up
+with development branches:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    anyrun.url = "github:anyrun-org/anyrun";
+  };
+  outputs = {self, ...}@inputs: {
+    homeConfigurations.user = inputs.home-manager.lib.homeManagerConfiguration {
+      modules = [
+        ({ modulesPath, ... }: {
+          # Important! We disable home-manager's module to avoid option
+          # definition collisions
+          disabledModules = ["${modulesPath}/programs/anyrun.nix"];
+        })
+        inputs.anyrun.homeManagerModules.default
+        {
+          programs.anyrun = {
+            # ...
+          };
+        }
+      ];
+    };
+  }
+}
+```
+
 Anyrun packages are built and cached automatically. To avoid unnecessary
 recompilations, you may use the binary cache.
 


### PR DESCRIPTION
Just keeping the module up to date. Added an `extraLines` option that gets inserted into the `Config` object so that users can take advantage of config changes without waiting for the module to be updated.

I also took the liberty of mentioning how to disable HM's module to use our own.