### PR TITLE
Fix behavior for clipboard managers

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -330,6 +330,11 @@ impl Component for App {
                 window.set_margin(Edge::Left, x);
                 window.set_margin(Edge::Top, y);
                 window.show();
+
+                // If show_results_immediately is enabled, trigger initial search with empty input
+                if self.config.show_results_immediately {
+                    self.plugins.broadcast(PluginBoxInput::EntryChanged(String::new()));
+                }
             }
             AppMsg::KeyPressed { key, modifier } => {
                 if let Some(Keybind { action, .. }) = self.config.keybinds.iter().find(|keybind| {

--- a/plugins/stdin/README.md
+++ b/plugins/stdin/README.md
@@ -16,6 +16,8 @@ Config(
   allow_invalid: false,
   // How many entries should be displayed at max
   max_entries: 5,
+  // Whether to preserve the original order of entries instead of sorting by fuzzy match score
+  preserve_order: false,
 )
 
 ```

--- a/plugins/stdin/src/lib.rs
+++ b/plugins/stdin/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 struct Config {
     allow_invalid: bool,
     max_entries: usize,
+    preserve_order: bool,
 }
 
 impl Default for Config {
@@ -16,6 +17,7 @@ impl Default for Config {
         Self {
             allow_invalid: false,
             max_entries: 5,
+            preserve_order: false,
         }
     }
 }
@@ -60,7 +62,9 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
         .collect::<Vec<_>>();
 
     if !lines.is_empty() {
-        lines.sort_by(|a, b| b.1.cmp(&a.1));
+        if !state.config.preserve_order {
+            lines.sort_by(|a, b| b.1.cmp(&a.1));
+        }
         lines.truncate(state.config.max_entries);
     } else if state.config.allow_invalid {
         lines.push((input.into(), 0));


### PR DESCRIPTION
This PR fixes 2 issues with anyrun + a clipboard manager(e.g. cliphist):
- No results from stdin is shown until I enter anything and remove. It looks like `show_results_immediately` wasn't used anywhere in the last update.
- The fuzzy match score is less important for when using with a clipboard manager, because you(me :D) expect records to stay in reverse chronological order but filtered by a fuzzy matcher.