### PR TITLE
anyrun: Fix freeze when closing

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -324,7 +324,7 @@ impl Component for App {
         widgets: &mut Self::Widgets,
         message: Self::Input,
         sender: ComponentSender<Self>,
-        root: &Self::Root,
+        _root: &Self::Root,
     ) {
         match message {
             AppMsg::Show {
@@ -373,13 +373,12 @@ impl Component for App {
             }
             AppMsg::Action(action) => match action {
                 Action::Close => {
-                    root.close();
                     relm4::main_application().quit();
                 }
                 Action::Select => {
                     if let Some((_, plugin, plugin_match)) = self.current_selection() {
                         match plugin.plugin.handle_selection()(plugin_match.content.clone()) {
-                            HandleResult::Close => root.close(),
+                            HandleResult::Close =>  relm4::main_application().quit(),
                             HandleResult::Refresh(exclusive) => {
                                 if exclusive {
                                     for (i, _plugin) in self.plugins.iter().enumerate() {


### PR DESCRIPTION
## Problem
Anyrun hangs when closing the application (via Escape key, select an APP or `close_on_click`), becoming unresponsive and keeping intercept keyboard/mouse events.

The `root.close()` call in the close handler appears to be causing the hang. It likely causing deadlocks during shutdown.

## Environment

Reproduced on NixOS unstable with Hyprland and Niri compositors.

## Solution
Remove `root.close()` calls and rely solely on `relm4::main_application().quit()`. After reviewing relm4's [examples](https://github.com/Relm4/Relm4/tree/main/examples), none of them call `root.close()` during exit - they let GTK handle window cleanup automatically.

## Testing
- [x] Tested on NixOS + Hyprland and Niri
- [x] Verified clean exit without hanging
- [x] Confirmed keyboard/mouse events are properly released