### PR TITLE
plugins/rink: Add prefix config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,8 @@ dependencies = [
  "anyrun-plugin",
  "reqwest 0.11.27",
  "rink-core",
+ "ron 0.8.1",
+ "serde",
 ]
 
 [[package]]

--- a/plugins/rink/Cargo.toml
+++ b/plugins/rink/Cargo.toml
@@ -13,3 +13,5 @@ anyrun-plugin = { path = "../../anyrun-plugin" }
 abi_stable = "0.11.1"
 rink-core = "0.6"
 reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+serde = { version = "1.0.219", features = ["derive"] }
+ron = "0.8.0"

--- a/plugins/rink/src/lib.rs
+++ b/plugins/rink/src/lib.rs
@@ -1,9 +1,29 @@
 use abi_stable::std_types::{ROption, RString, RVec};
 use anyrun_plugin::*;
 use rink_core::{ast, date, gnu_units, CURRENCY_FILE};
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize, Debug)]
+struct Config {
+    prefix: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            prefix: "".to_string(),
+        }
+    }
+}
+
+struct State {
+    ctx: rink_core::Context,
+    config: Config,
+}
 
 #[init]
-fn init(_config_dir: RString) -> rink_core::Context {
+fn init(config_dir: RString) -> State {
     let mut ctx = rink_core::Context::new();
 
     let units = gnu_units::parse_str(rink_core::DEFAULT_FILE.unwrap());
@@ -29,7 +49,18 @@ fn init(_config_dir: RString) -> rink_core::Context {
     });
     ctx.load_dates(dates);
 
-    ctx
+    let config = match fs::read_to_string(format!("{}/rink.ron", config_dir)) {
+        Ok(content) => ron::from_str(&content).unwrap_or_else(|why| {
+            eprintln!("[nix-run] Failed to parse config: {}", why);
+            Config::default()
+        }),
+        Err(why) => {
+            eprintln!("[nix-run] No config file provided, using default: {}", why);
+            Config::default()
+        }
+    };
+
+    State { ctx, config }
 }
 
 #[info]
@@ -41,8 +72,14 @@ fn info() -> PluginInfo {
 }
 
 #[get_matches]
-fn get_matches(input: RString, ctx: &mut rink_core::Context) -> RVec<Match> {
-    match rink_core::one_line(ctx, &input) {
+fn get_matches(input: RString, state: &mut State) -> RVec<Match> {
+    let input = if let Some(input) = input.strip_prefix(&state.config.prefix) {
+        input.trim()
+    } else {
+        return RVec::new();
+    };
+
+    match rink_core::one_line(&mut state.ctx, &input) {
         Ok(result) => {
             let (title, desc) = parse_result(result);
             vec![Match {


### PR DESCRIPTION
I wanted to be able to use = as a prefix for the rink plugin, so I implemented the prefix config option for it. I mostly copied the structure from the nix-run. Let me know if any changes should be made!