### PR TITLE
Make clicking on a match select it on close-on-click (Fixes #149)

### DIFF
--- a/anyrun/src/main.rs
+++ b/anyrun/src/main.rs
@@ -472,6 +472,11 @@ impl Component for App {
                     }
                 }
             }
+            AppMsg::PluginOutput(PluginBoxOutput::MatchClicked) => {
+                if self.config.close_on_click {
+                    sender.input(AppMsg::Action(Action::Select));
+                }
+            }
         }
         self.update_view(widgets, sender);
     }


### PR DESCRIPTION
Modify `PluginMatch` box to handle GestureClick and claim the event, manually selecting the row. Then also output a `Clicked` event, which is passed on to the main app events.
On this event, if `close-on-click` is true, do perform the `Select` action, picking the item and running its result.

This changes the behaviour (for close-on-click=true) on clicking menu items, selecting them instead of just closing the application.