### PR TITLE
Fixed initial positioning artifact

### DIFF
--- a/anyrun/src/app.rs
+++ b/anyrun/src/app.rs
@@ -140,6 +140,14 @@ impl Component for App {
 
             connect_map[sender] => move |win| {
                 let surface = win.surface().unwrap();
+                match surface.display().monitor_at_surface(&surface) {
+                    Some(monitor) => sender.input(AppMsg::Show {
+                        width: monitor.geometry().width() as u32,
+                        height: monitor.geometry().height() as u32,
+                    }),
+                    _ => ()
+                };
+
                 let sender = sender.clone();
                 surface.connect_enter_monitor(move |_, monitor| {
                     sender.input(AppMsg::Show {


### PR DESCRIPTION
## Summary
Sends `AppMsg::Show` right after `connect_map`, as there is some time-delay between `window.show()` and `connect_enter_monitor`, creating visual artifacts.

## Motivation
#262 

## Screenrecords
https://github.com/user-attachments/assets/cfc5648c-dc38-4a81-be90-9c3ba6f1bb55

