### PR TITLE
Fixed CSS relative path imports in style.css loading

### DIFF
--- a/anyrun/src/app.rs
+++ b/anyrun/src/app.rs
@@ -234,8 +234,9 @@ impl Component for App {
         let css_provider = gtk::CssProvider::new();
 
         let mut config = if let Some(config_dir) = &config_dir {
-            if Path::new(&format!("{config_dir}/style.css")).exists() {
-                css_provider.load_from_path(format!("{config_dir}/style.css"));
+            let css_path = Path::new(&config_dir).join("style.css");
+            if css_path.exists() {
+                css_provider.load_from_path(css_path);
             } else {
                 eprintln!("[anyrun] {config_dir}/style.css does not exist");
                 css_provider.load_from_string(DEFAULT_CSS);


### PR DESCRIPTION
This pull request adds support for relative paths when using '@import' in style.css.

### Problem
When using '@import' in style.css, relative paths fail because 'load_from_string()' does not provide GTK with file context, and thus relative paths become un-resolve-able.

### Solution
Changed *css_provider.load_from_string()* to *css_provider.load_from_path()*, which provides the necessary path context under the hood.

### Texting/Verification
Verified url style imports, absolute paths, and relative paths, didn't break anything, and now I can @import "./colors.css" without issue. Was this necessary? No. Do I hope you merge it? Yes, pretty please.
