### PR TITLE
feat(applications): add configurable environment variables and debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "fuzzy-matcher",
  "ron 0.8.1",
  "serde",
+ "shellexpand",
  "sublime_fuzzy",
 ]
 
@@ -582,6 +583,27 @@ dependencies = [
  "reqwest 0.11.27",
  "ron 0.8.1",
  "serde",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1621,6 +1643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1913,12 @@ dependencies = [
  "pathdiff",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pango"
@@ -2145,6 +2183,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2563,6 +2612,15 @@ dependencies = [
  "anyrun-plugin",
  "ron 0.8.1",
  "serde",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/plugins/applications/Cargo.toml
+++ b/plugins/applications/Cargo.toml
@@ -14,4 +14,5 @@ anyrun-plugin = { path = "../../anyrun-plugin" }
 fuzzy-matcher = "0.3.7"
 ron           = "0.8.0"
 serde         = { features = [ "derive" ], version = "1.0.228" }
+shellexpand   = "3"
 sublime_fuzzy = "0.7.0"


### PR DESCRIPTION
- Add EnvironmentVariables enum with None/Inherit/Script(PathBuf) options
- Add environment_variables config field to allow users to:
  - Inherit current process environment
  - Run custom script to generate environment variables
- Add LogLevel enum (Error/Debug) with log_level config field
- Add debug logging that outputs cwd, args, and envs before command execution
- Add shellexpand dependency for tilde expansion in script paths
- Update all Command spawn sites to use configurable environment variables

BREAKING CHANGE: None (new optional config fields with safe defaults)