### PR TITLE
plugins/applications: Use preprocessed `exec` instead of raw `entry.exec`

### DIFF
--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -143,7 +143,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
 
         Command::new("sh")
             .arg("-c")
-            .arg(&entry.exec)
+            .arg(&exec)
             .current_dir(match &entry.path {
                 Some(path) if path.exists() => path,
                 _ => current_dir,


### PR DESCRIPTION
The preprocessed `exec` command was not being used for non-terminal applications, causing the `preprocess_exec_script` to be ignored in those cases.