### PR TITLE
add shell plugin history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1787,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1922,12 @@ dependencies = [
  "pathdiff",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pango"
@@ -2145,6 +2192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2561,6 +2619,9 @@ version = "25.12.0"
 dependencies = [
  "abi_stable",
  "anyrun-plugin",
+ "dirs",
+ "indexmap",
+ "nucleo-matcher",
  "ron 0.8.1",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,6 +1550,8 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1784,16 +1786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nucleo-matcher"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
-dependencies = [
- "memchr",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2570,15 +2562,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2620,10 +2612,11 @@ dependencies = [
  "abi_stable",
  "anyrun-plugin",
  "dirs",
+ "fuzzy-matcher",
  "indexmap",
- "nucleo-matcher",
  "ron 0.8.1",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3838,3 +3831,9 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -9,7 +9,10 @@ crate-type = [ "cdylib" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-abi_stable    = "0.11.1"
-anyrun-plugin = { path = "../../anyrun-plugin" }
-ron           = "0.8.0"
-serde         = { features = [ "derive" ], version = "1.0.228" }
+abi_stable     = "0.11.1"
+anyrun-plugin  = { path = "../../anyrun-plugin" }
+dirs           = "6.0.0"
+indexmap       = "2.12.1"
+nucleo-matcher = "0.3.1"
+ron            = "0.8.0"
+serde          = { features = [ "derive" ], version = "1.0.228" }

--- a/plugins/shell/Cargo.toml
+++ b/plugins/shell/Cargo.toml
@@ -9,10 +9,11 @@ crate-type = [ "cdylib" ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-abi_stable     = "0.11.1"
-anyrun-plugin  = { path = "../../anyrun-plugin" }
-dirs           = "6.0.0"
-indexmap       = "2.12.1"
-nucleo-matcher = "0.3.1"
-ron            = "0.8.0"
-serde          = { features = [ "derive" ], version = "1.0.228" }
+abi_stable    = "0.11.1"
+anyrun-plugin = { path = "../../anyrun-plugin" }
+dirs          = "6.0.0"
+fuzzy-matcher = "0.3.7"
+indexmap      = { features = [ "serde" ], version = "2.12.1" }
+ron           = "0.8.0"
+serde         = { features = [ "derive" ], version = "1.0.228" }
+serde_json    = "1.0.149"

--- a/plugins/shell/README.md
+++ b/plugins/shell/README.md
@@ -14,10 +14,11 @@ Config(
   prefix: ":sh",
   // Override the shell used to launch the command
   shell: None,
-  // None to disable history (default)
-  // note the double parens
-  history: Some((
-    capacity: 100,
-    )),
+  max_entries: 10,
+  // to enable history: 
+  // Some((
+  //  capacity: 100,
+  //  )),
+  history: None,
 )
 ```

--- a/plugins/shell/README.md
+++ b/plugins/shell/README.md
@@ -14,5 +14,10 @@ Config(
   prefix: ":sh",
   // Override the shell used to launch the command
   shell: None,
+  // None to disable history (default)
+  // note the double parens
+  history: Some((
+    capacity: 100,
+    )),
 )
 ```

--- a/plugins/shell/src/history.rs
+++ b/plugins/shell/src/history.rs
@@ -19,7 +19,7 @@ pub struct History {
 impl History {
     pub fn new(history_config: &HistoryConfig) -> History {
         let maybe_history_file =
-            dirs::state_dir().map(|s| s.join("anyrun").join("shell_history.txt"));
+            dirs::state_dir().map(|s| s.join("anyrun").join("shell").join("shell_history.txt"));
 
         let backing_store = if let Some(history_file) = maybe_history_file {
             let file = (|| {

--- a/plugins/shell/src/history.rs
+++ b/plugins/shell/src/history.rs
@@ -1,0 +1,99 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+
+use indexmap::IndexSet;
+
+use crate::HistoryConfig;
+
+pub enum HistoryBackingStore {
+    File(File),
+    Memory,
+}
+
+pub struct History {
+    pub backing_store: HistoryBackingStore,
+    pub elements: IndexSet<String>,
+    pub cap: usize,
+}
+
+impl History {
+    pub fn new(history_config: &HistoryConfig) -> History {
+        let maybe_history_file =
+            dirs::state_dir().map(|s| s.join("anyrun").join("shell_history.txt"));
+
+        let backing_store = if let Some(history_file) = maybe_history_file {
+            let file = (|| {
+                if let Some(dir) = history_file.parent() {
+                    std::fs::create_dir_all(dir)?;
+                }
+
+                File::options()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&history_file)
+            })();
+
+            match file {
+                Ok(f) => HistoryBackingStore::File(f),
+                Err(ref err) => {
+                    eprintln!("[shell] Failed to create file {} to persist shell plugin history, falling back to in-memory: {}", &history_file.to_string_lossy(), err.kind());
+                    HistoryBackingStore::Memory
+                }
+            }
+        } else {
+            HistoryBackingStore::Memory
+        };
+
+        match backing_store {
+            HistoryBackingStore::File(file) => History::from_file(history_config.capacity, file)
+                .unwrap_or_else(|err| {
+                    eprintln!("[shell] Failed to initialize history from file: {:?}", err);
+                    History::from_mem(history_config.capacity)
+                }),
+            HistoryBackingStore::Memory => History::from_mem(history_config.capacity),
+        }
+    }
+
+    pub fn push(&mut self, value: String) -> Result<(), std::io::Error> {
+        // insert_before ensures new usages of existing commands bubble up to the top of the history, simple `insert` does not
+        self.elements.insert_before(self.elements.len(), value);
+
+        if self.elements.len() > self.cap {
+            let remove_count = self.elements.len().saturating_sub(self.cap);
+            self.elements.drain(0..remove_count);
+        }
+
+        if let HistoryBackingStore::File(file) = &mut self.backing_store {
+            file.seek(SeekFrom::Start(0))?;
+            file.set_len(0)?;
+            for line in &self.elements {
+                writeln!(file, "{}", line)?;
+            }
+            file.flush()?;
+        }
+
+        Ok(())
+    }
+
+    fn from_mem(cap: usize) -> History {
+        History {
+            backing_store: HistoryBackingStore::Memory,
+            elements: IndexSet::new(),
+            cap,
+        }
+    }
+
+    fn from_file(cap: usize, file: File) -> Result<History, std::io::Error> {
+        let elements: IndexSet<String> = BufReader::new(&file)
+            .lines()
+            .collect::<std::io::Result<_>>()?;
+
+        Ok(History {
+            backing_store: HistoryBackingStore::File(file),
+            elements,
+            cap,
+        })
+    }
+}

--- a/plugins/shell/src/history.rs
+++ b/plugins/shell/src/history.rs
@@ -13,7 +13,7 @@ struct PersistedHistory<T> {
 type PersistedHistoryOwned = PersistedHistory<IndexSet<HistoryItem>>;
 type PersistedHistoryBorrowed<'a> = PersistedHistory<&'a IndexSet<HistoryItem>>;
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct HistoryItem {
     pub command: String,
 }
@@ -24,6 +24,7 @@ impl HistoryItem {
     }
 }
 
+#[derive(Debug)]
 pub struct History {
     store: File,
     elements: IndexSet<HistoryItem>,

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -18,13 +18,15 @@ struct HistoryConfig {
 struct Config {
     prefix: String,
     shell: Option<String>,
-    #[serde(default = "default_max_entries")]
+    #[serde(default = "Config::default_max_entries")]
     max_entries: usize,
     history: Option<HistoryConfig>,
 }
 
-fn default_max_entries() -> usize {
-    10
+impl Config {
+    fn default_max_entries() -> usize {
+        10
+    }
 }
 
 impl Default for Config {
@@ -32,7 +34,7 @@ impl Default for Config {
         Config {
             prefix: ":sh".to_string(),
             shell: None,
-            max_entries: default_max_entries(),
+            max_entries: Config::default_max_entries(),
             history: None,
         }
     }

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -18,7 +18,13 @@ struct HistoryConfig {
 struct Config {
     prefix: String,
     shell: Option<String>,
+    #[serde(default = "default_max_entries")]
+    max_entries: usize,
     history: Option<HistoryConfig>,
+}
+
+fn default_max_entries() -> usize {
+    10
 }
 
 impl Default for Config {
@@ -26,6 +32,7 @@ impl Default for Config {
         Config {
             prefix: ":sh".to_string(),
             shell: None,
+            max_entries: default_max_entries(),
             history: None,
         }
     }
@@ -98,6 +105,7 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
             std::iter::once(input)
                 .chain(history_matches.into_iter())
+                .take(config.max_entries)
                 .map(|cmd| Match {
                     title: cmd.into(),
                     description: ROption::RSome(

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -44,7 +44,13 @@ fn init(config_dir: RString) -> State {
         Ok(content) => {
             let config: Config = ron::from_str(&content).unwrap_or_default();
 
-            let history = config.history.as_ref().map(History::new);
+            let history = config.history.as_ref().and_then(|h| match History::new(h) {
+                Ok(history) => Some(history),
+                Err(err) => {
+                    eprintln!("[shell] Failed to initialize history: {}", err);
+                    None
+                }
+            });
 
             State { config, history }
         }

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -2,12 +2,24 @@ use std::{env, fs, process::Command};
 
 use abi_stable::std_types::{ROption, RString, RVec};
 use anyrun_plugin::*;
+use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization};
+use nucleo_matcher::Matcher;
 use serde::Deserialize;
+
+use self::history::History;
+
+mod history;
+
+#[derive(Deserialize)]
+struct HistoryConfig {
+    capacity: usize,
+}
 
 #[derive(Deserialize)]
 struct Config {
     prefix: String,
     shell: Option<String>,
+    history: Option<HistoryConfig>,
 }
 
 impl Default for Config {
@@ -15,15 +27,28 @@ impl Default for Config {
         Config {
             prefix: ":sh".to_string(),
             shell: None,
+            history: None,
         }
     }
 }
 
+#[derive(Default)]
+struct State {
+    config: Config,
+    history: Option<History>,
+}
+
 #[init]
-fn init(config_dir: RString) -> Config {
+fn init(config_dir: RString) -> State {
     match fs::read_to_string(format!("{}/shell.ron", config_dir)) {
-        Ok(content) => ron::from_str(&content).unwrap_or_default(),
-        Err(_) => Config::default(),
+        Ok(content) => {
+            let config: Config = ron::from_str(&content).unwrap_or_default();
+
+            let history = config.history.as_ref().map(History::new);
+
+            State { config, history }
+        }
+        Err(_) => State::default(),
     }
 }
 
@@ -36,28 +61,51 @@ fn info() -> PluginInfo {
 }
 
 #[get_matches]
-fn get_matches(input: RString, config: &Config) -> RVec<Match> {
+fn get_matches(input: RString, state: &State) -> RVec<Match> {
+    let config = &state.config;
     if input.starts_with(&config.prefix) {
         let (_, command) = input.split_once(&config.prefix).unwrap();
+        let command = command.trim();
         if !command.is_empty() {
-            vec![Match {
-                title: command.trim().into(),
-                description: ROption::RSome(
-                    config
-                        .shell
-                        .clone()
-                        .unwrap_or_else(|| {
-                            env::var("SHELL").unwrap_or_else(|_| {
-                                "The shell could not be determined!".to_string()
+            let matches = if let Some(history) = &state.history {
+                let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+                let matches = Atom::new(
+                    command,
+                    CaseMatching::Ignore,
+                    Normalization::Smart,
+                    AtomKind::Fuzzy,
+                    false,
+                )
+                .match_list(&history.elements, &mut matcher)
+                .into_iter()
+                .map(|(s, _)| s.as_str())
+                .collect();
+                matches
+            } else {
+                vec![command]
+            };
+
+            std::iter::once(command)
+                .chain(matches.into_iter())
+                .map(|cmd| Match {
+                    title: cmd.into(),
+                    description: ROption::RSome(
+                        config
+                            .shell
+                            .clone()
+                            .unwrap_or_else(|| {
+                                env::var("SHELL").unwrap_or_else(|_| {
+                                    "The shell could not be determined!".to_string()
+                                })
                             })
-                        })
-                        .into(),
-                ),
-                use_pango: false,
-                icon: ROption::RNone,
-                id: ROption::RNone,
-            }]
-            .into()
+                            .into(),
+                    ),
+                    use_pango: false,
+                    icon: ROption::RNone,
+                    id: ROption::RNone,
+                })
+                .collect::<Vec<Match>>()
+                .into()
         } else {
             RVec::new()
         }
@@ -67,7 +115,13 @@ fn get_matches(input: RString, config: &Config) -> RVec<Match> {
 }
 
 #[handler]
-fn handler(selection: Match) -> HandleResult {
+fn handler(selection: Match, state: &mut State) -> HandleResult {
+    if let Some(history) = state.history.as_mut() {
+        if let Err(err) = history.push(selection.title.clone().into_string()) {
+            eprintln!("[shell] Failed to push command to history: {:?}", err);
+        }
+    }
+
     if let Err(why) = Command::new(selection.description.unwrap().as_str())
         .arg("-c")
         .arg(selection.title.as_str())

--- a/plugins/shell/src/lib.rs
+++ b/plugins/shell/src/lib.rs
@@ -85,8 +85,7 @@ fn get_matches(input: RString, state: &State) -> RVec<Match> {
                 .map(|history| {
                     let matcher = fuzzy_matcher::skim::SkimMatcherV2::default().ignore_case();
                     let mut matches = history
-                        .elements
-                        .iter()
+                        .elements()
                         .filter_map(|s| {
                             matcher
                                 .fuzzy_match(&s.command, input)


### PR DESCRIPTION
thanks for the wonderful project
I was missing this feature after migrating to anyrun so added it for my selfish self, but PRing in case you think it could be useful to others

- saves the history up to a configurable limit in $XDG_STATE_DIR/anyrun, or in memory if that fails (i'm not 100% convinced that's useful enough to keep, may be better to just disable history entirely in that case. I can be persuaded either way :))

- deduplicates on submit, only one entry for each distinct command

- reusing an old command again makes it bubble up the history

- the added `dirs` and `indexmap` dependencies are imo not problematic. on the fuzzy matcher am open to alternatives if there are better options

kept it simple, didn't put effort into parsing the shell grammars for supporting multiline and so on, deep rabbit hole there imo

appreciate feedback and happy to make changes