### PR TITLE
plugins(websearch): support custom engine icons

### DIFF
--- a/plugins/websearch/README.md
+++ b/plugins/websearch/README.md
@@ -23,9 +23,27 @@ Config(
   // Custom(
   //   name: "Searx",
   //   url: "searx.be/?q={}",
+  //   icon: Some("/path/to/icon.png"),  //can be left out entirely
   // )
   //
   // NOTE: `{}` is replaced by the search query and `https://` is automatically added in front.
   engines: [Google] 
 )
 ```
+
+### Icons
+
+The Custom engine icon can be one of:
+
+- an icon name supported by your theme:
+  ```ron
+  Some("view-more-symbolic")
+  ```
+- an icon name from the [freedesktop.org icon naming spec](https://specifications.freedesktop.org/icon-naming/latest/):
+  ```ron
+  Some("help-about")
+  ```
+- an absolute path to an icon, e.g.
+  ```ron
+  Some("/absolute/path/to/icon.png")
+  ```

--- a/plugins/websearch/src/lib.rs
+++ b/plugins/websearch/src/lib.rs
@@ -10,7 +10,12 @@ enum Engine {
     Ecosia,
     Bing,
     DuckDuckGo,
-    Custom { name: String, url: String },
+    Custom {
+        name: String,
+        url: String,
+        #[serde(default)]
+        icon: Option<String>,
+    },
 }
 
 impl Engine {
@@ -81,7 +86,10 @@ fn get_matches(input: RString, config: &Config) -> RVec<Match> {
                 title: input.trim_start_matches(&config.prefix).into(),
                 description: ROption::RSome(format!("Search with {}", engine).into()),
                 use_pango: false,
-                icon: ROption::RNone,
+                icon: match engine {
+                    Engine::Custom { icon: Some(i), .. } => ROption::RSome(i.clone().into()),
+                    _ => ROption::RNone,
+                },
                 id: ROption::RSome(i as u64),
             })
             .collect()


### PR DESCRIPTION
this is useful as a visual cue for people who have more than two or three custom engines
could potentially include icons for the built-in engines but I think the tradeoff there is not so clear (not so likely people will have more than one or two of those, and we would have to bundle the icons)