### PR TITLE
feat: mouse scrolling

### DIFF
--- a/anyrun/src/app.rs
+++ b/anyrun/src/app.rs
@@ -208,6 +208,7 @@ impl Component for App {
                 // Scrollable results
                 #[name = "results"]
                 gtk::ScrolledWindow {
+                    set_can_focus: false,
                     set_hscrollbar_policy: gtk::PolicyType::Never,
                     set_vscrollbar_policy: if config.scroll {
                         gtk::PolicyType::Automatic
@@ -477,8 +478,8 @@ impl Component for App {
                     self.plugins.broadcast(PluginBoxInput::MaybeHide);
                 }
 
-                // Clamping the results height to min/max values set in config
-                // Also follows content size
+                // Workaround for max_content_height not taking effect 
+                    // (the full height is set by min_content_height)
                 let min_height = widgets.results.min_content_height();
                 let max_height = widgets.results.max_content_height();
                 let (_, natural_height, _, _) = self.plugins.widget().measure(gtk::Orientation::Vertical, -1);

--- a/anyrun/src/app.rs
+++ b/anyrun/src/app.rs
@@ -204,12 +204,29 @@ impl Component for App {
                         }
                     }
                 },
-                #[local]
-                plugins -> gtk::Box {
-                    set_orientation: gtk::Orientation::Vertical,
-                    set_can_focus: false,
-                    set_css_classes: &["matches"],
+
+                // Scrollable results
+                #[name = "results"]
+                gtk::ScrolledWindow {
+                    set_hscrollbar_policy: gtk::PolicyType::Never,
+                    set_vscrollbar_policy: if config.scroll {
+                        gtk::PolicyType::Automatic
+                    } else {
+                        gtk::PolicyType::Never
+                    },
+
+                    set_min_content_height: config.min_results_height,
+                    set_max_content_height: config.max_results_height,
+                    set_css_classes: &["results"],
                     set_hexpand: true,
+
+                    #[local]
+                    plugins -> gtk::Box {
+                        set_orientation: gtk::Orientation::Vertical,
+                        set_can_focus: false,
+                        set_css_classes: &["matches"],
+                        set_hexpand: true,
+                    }
                 }
             }
         }
@@ -459,7 +476,22 @@ impl Component for App {
                     }
                     self.plugins.broadcast(PluginBoxInput::MaybeHide);
                 }
+
+                // Clamping the results height to min/max values set in config
+                // Also follows content size
+                let min_height = widgets.results.min_content_height();
+                let max_height = widgets.results.max_content_height();
+                let (_, natural_height, _, _) = self.plugins.widget().measure(gtk::Orientation::Vertical, -1);
+
+                let height = if max_height > 0 {
+                    natural_height.clamp(min_height, max_height)
+                } else {
+                    natural_height.max(min_height)
+                };
+
+                widgets.results.set_height_request(height);
             }
+
             // Handle clicked selections
             AppMsg::PluginOutput(PluginBoxOutput::RowSelected(index)) => {
                 for (i, plugin) in self.plugins.iter().enumerate() {

--- a/anyrun/src/config.rs
+++ b/anyrun/src/config.rs
@@ -16,6 +16,14 @@ pub struct Config {
     pub width: RelativeNum,
     #[serde(default = "Config::default_height")]
     pub height: RelativeNum,
+    
+    #[serde(default = "Config::default_min_results_height")]
+    pub min_results_height: i32,
+    #[serde(default = "Config::default_max_results_height")]
+    pub max_results_height: i32,
+
+    #[serde(default = "Config::default_scroll")]
+    pub scroll: bool,
 
     #[serde(default = "Config::default_plugins")]
     pub plugins: Vec<PathBuf>,
@@ -60,6 +68,17 @@ impl Config {
 
     fn default_height() -> RelativeNum {
         RelativeNum::Absolute(1)
+    }
+
+    fn default_min_results_height() -> i32 {
+        0
+    }
+    fn default_max_results_height() -> i32 {
+        400
+    }
+
+    fn default_scroll() -> bool {
+        false
     }
 
     fn default_plugins() -> Vec<PathBuf> {
@@ -137,6 +156,9 @@ impl Default for Config {
             y: Self::default_y(),
             width: Self::default_width(),
             height: Self::default_height(),
+            min_results_height: Self::default_min_results_height(),
+            max_results_height: Self::default_max_results_height(),
+            scroll: Self::default_scroll(),
             plugins: Self::default_plugins(),
             provider: Self::default_provider(),
             hide_icons: false,


### PR DESCRIPTION
Added a method for having scrollable plugins. You can configure these options in config.ron:

- `min_results_height`(i32): the minimum possible scrolling window. Default `0`.
- `max_results_height`(i32): the maximum possible scroll window. Default `400`.
- `scroll`(bool): whether or not to enable scrolling behavior. Default `false`.

Implemented this by wrapping the plugins box in a gtk-scrolledWindow.
- scrolledWindow name and css class name is `results`.