### PR TITLE
plugins/translate: fix punjabi typo

### DIFF
--- a/plugins/translate/src/lib.rs
+++ b/plugins/translate/src/lib.rs
@@ -115,7 +115,7 @@ fn init(config_dir: RString) -> State {
             ("fa", "Persian"),
             ("pl", "Polish"),
             ("pt", "Portuguese"),
-            ("ma", "Punjabi"),
+            ("pa", "Punjabi"),
             ("ro", "Romanian"),
             ("ru", "Russian"),
             ("sm", "Samoan"),


### PR DESCRIPTION
Google Translate uses `pa` for Punjabi, not `ma`.

one line change ¯\\\_(ツ)_/¯