### PR TITLE
plugins/applications: several fixes

### DIFF
--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -17,6 +17,7 @@ pub struct Config {
     hide_description: bool,
     terminal: Option<Terminal>,
     preprocess_exec_script: Option<PathBuf>,
+    prioritize_actions: bool,
 }
 
 #[derive(Deserialize)]
@@ -33,6 +34,7 @@ impl Default for Config {
             hide_description: false,
             preprocess_exec_script: None,
             terminal: None,
+            prioritize_actions: true,
         }
     }
 }
@@ -187,8 +189,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
             let mut score = (name_score * 10 + desc_score + keyword_score) - entry.offset;
 
-            // prioritize actions
-            if entry.is_action {
+            if state.config.prioritize_actions && entry.is_action {
                 score *= 2;
             }
 

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -132,6 +132,9 @@ const TERMINAL_COMMAND_FORMATS: &[&str] = &[
     "gnome-terminal -- {}",
     "konsole -e {}",
     "xterm -e {}",
+
+    // Check that the terminal handle unquoted commands correctly before adding it here
+    // Also, the order matter, the first ones are tried first
 ];
 
 fn get_terminal_command_format(config: &Config) -> Option<String> {
@@ -141,8 +144,6 @@ fn get_terminal_command_format(config: &Config) -> Option<String> {
 
     for cmd_fmt in TERMINAL_COMMAND_FORMATS {
         if Command::new("which")
-            // The first .next() on Split cannot panic: if the string
-            // is empty, it returns Some("")
             .arg(cmd_fmt.split(' ').next().unwrap())
             .output()
             .is_ok_and(|output| output.status.success())
@@ -185,7 +186,7 @@ pub fn init(config_dir: RString) -> State {
 #[get_matches]
 pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
     let matcher = fuzzy_matcher::skim::SkimMatcherV2::default().ignore_case();
-    let mut entries = state
+    let mut matching_entries = state
         .entries
         .iter()
         .enumerate()
@@ -195,6 +196,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
                     .fuzzy_match(&entry.localized_name(), &input)
                     .unwrap_or(0),
             );
+
             let desc_score = entry
                 .desc
                 .as_ref()
@@ -222,10 +224,10 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
         })
         .collect::<Vec<_>>();
 
-    entries.sort_by(|a, b| b.2.cmp(&a.2).then(a.0.name.cmp(&b.0.name)));
+    matching_entries.sort_by(|a, b| b.2.cmp(&a.2).then(a.0.name.cmp(&b.0.name)));
 
-    entries.truncate(state.config.max_entries);
-    entries
+    matching_entries.truncate(state.config.max_entries);
+    matching_entries
         .into_iter()
         .map(|(entry, id, _)| Match {
             title: entry.localized_name().into(),

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -175,10 +175,11 @@ pub fn init(config_dir: RString) -> State {
         }
     };
 
-    let entries = scrubber::scrubber(&config).unwrap_or_else(|why| {
-        eprintln!("[applicatiosn] Failed to load desktop entries: {}", why);
-        Vec::new()
-    });
+    let entries = scrubber::scrubber(&config);
+
+    if entries.is_empty() {
+        eprintln!("[applications] Warning: no desktop entries found")
+    }
 
     State { config, entries }
 }

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -54,7 +54,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
                 "{} {} {}",
                 script.display(),
                 if entry.term { "term" } else { "no-term" },
-                &entry.exec
+                entry.exec
             ))
             .output()
             .unwrap_or_else(|why| {

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -4,9 +4,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use scrubber::DesktopEntry;
 use serde::Deserialize;
 use std::{
-    env, fs, io,
-    path::{Path, PathBuf},
-    process::Command,
+    env, fs, io, path::{Path, PathBuf}, process::{Command, Stdio},
 };
 
 #[derive(Deserialize)]
@@ -59,10 +57,18 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
                 if entry.term { "term" } else { "no-term" },
                 entry.exec
             ))
-            .output();
+            .stdout(Stdio::piped())
+            .spawn()
+            .and_then(|c| c.wait_with_output());
 
         match output_res {
-            Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            Ok(output) if output.status.success() => {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            }
+            Ok(output_failed) => {
+                eprintln!("[applications] Preprocess script failed with status code: {}", output_failed.status);
+                return HandleResult::Close;
+            }
             Err(why) => {
                 eprintln!("[applications] Error running preprocess script: {}", why);
                 return HandleResult::Close;
@@ -71,6 +77,10 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
     } else {
         entry.exec.clone()
     };
+
+    if command.is_empty() {
+        return HandleResult::Close;
+    }
 
     if entry.term {
         command = match get_terminal_command_format(&state.config) {

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -63,7 +63,16 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
 
         match output_res {
             Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout).trim().to_string()
+                let stdout = match String::from_utf8(output.stdout) {
+                    Ok(out) => out,
+                    Err(why) => {
+                        // Stop here instead of using String::from_utf8_lossy(), which may introduce unexpected behaviours
+                        eprintln!("[applications] Preprocess script did output a non-valid UTF-8 string: {}", why);
+
+                        return HandleResult::Close;
+                    }
+                };
+                stdout.trim().to_string()
             }
             Ok(output_failed) => {
                 eprintln!("[applications] Preprocess script failed with status code: {}", output_failed.status);

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -69,8 +69,8 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
     };
 
     if entry.term {
-        command = match make_terminal_command(&command, &state.config) {
-            Some(cmd) => cmd,
+        command = match get_terminal_command_format(&state.config) {
+            Some(cmd_fmt) => cmd_fmt.replace("{}", &command),
             None => {
                 eprintln!("[applications] Error running terminal desktop entry: No terminal found");
 
@@ -99,52 +99,33 @@ fn run_command(command: &str, path: Option<&Path>) -> io::Result<std::process::C
         .spawn()
 }
 
-fn make_terminal_command(command: &str, config: &Config) -> Option<String> {
+const TERMINAL_COMMAND_FORMATS: &[&str] = &[
+    "alacritty -e {}",
+    "foot -e \"{}\"",
+    "kitty -e \"{}\"",
+    "wezterm -e \"{}\"",
+    "wterm -e \"{}\"",
+    "ghostty -e \"{}\"",
+];
+
+fn get_terminal_command_format(config: &Config) -> Option<String> {
     if let Some(term) = &config.terminal {
         return Some(format!(
             "{} {}",
             term.command,
-            term.args.replace("{}", command)
+            term.args
         ));
     }
 
-    let sensible_terminals = &[
-        Terminal {
-            command: "alacritty".to_string(),
-            args: "-e {}".to_string(),
-        },
-        Terminal {
-            command: "foot".to_string(),
-            args: "-e \"{}\"".to_string(),
-        },
-        Terminal {
-            command: "kitty".to_string(),
-            args: "-e \"{}\"".to_string(),
-        },
-        Terminal {
-            command: "wezterm".to_string(),
-            args: "-e \"{}\"".to_string(),
-        },
-        Terminal {
-            command: "wterm".to_string(),
-            args: "-e \"{}\"".to_string(),
-        },
-        Terminal {
-            command: "ghostty".to_string(),
-            args: "-e \"{}\"".to_string(),
-        },
-    ];
-    for term in sensible_terminals {
+    for cmd_fmt in TERMINAL_COMMAND_FORMATS {
         if Command::new("which")
-            .arg(&term.command)
+            // The first .next() on Split cannot panic: if the string
+            // is empty, it returns Some("")
+            .arg(cmd_fmt.split(' ').next().unwrap())
             .output()
             .is_ok_and(|output| output.status.success())
         {
-            return Some(format!(
-                "{} {}",
-                term.command,
-                term.args.replace("{}", command)
-            ));
+            return Some(cmd_fmt.to_string());
         }
     }
 

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -35,7 +35,7 @@ impl Default for Config {
 
 pub struct State {
     config: Config,
-    entries: Vec<(DesktopEntry, u64)>,
+    entries: Vec<DesktopEntry>,
 }
 
 mod scrubber;
@@ -44,14 +44,7 @@ mod scrubber;
 pub fn handler(selection: Match, state: &State) -> HandleResult {
     let entry = state
         .entries
-        .iter()
-        .find_map(|(entry, id)| {
-            if *id == selection.id.unwrap() {
-                Some(entry)
-            } else {
-                None
-            }
-        })
+        .get(selection.id.unwrap() as usize)
         .unwrap();
 
     let exec = if let Some(script) = &state.config.preprocess_exec_script {
@@ -190,7 +183,8 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
     let mut entries = state
         .entries
         .iter()
-        .filter_map(|(entry, id)| {
+        .enumerate()
+        .filter_map(|(i, entry)| {
             let name_score = matcher.fuzzy_match(&entry.name, &input).unwrap_or(0).max(
                 matcher
                     .fuzzy_match(&entry.localized_name(), &input)
@@ -217,7 +211,7 @@ pub fn get_matches(input: RString, state: &State) -> RVec<Match> {
 
             // Score cutoff
             if score > 0 {
-                Some((entry, *id, score))
+                Some((entry, i as u64, score))
             } else {
                 None
             }

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -51,7 +51,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
     let entry = state.entries.get(selection.id.unwrap() as usize).unwrap();
 
     let mut command = if let Some(script) = &state.config.preprocess_exec_script {
-        let output = Command::new("sh")
+        let output_res = Command::new("sh")
             .arg("-c")
             .arg(format!(
                 "{} {} {}",
@@ -59,13 +59,15 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
                 if entry.term { "term" } else { "no-term" },
                 entry.exec
             ))
-            .output()
-            .unwrap_or_else(|why| {
-                eprintln!("[applications] Error running preprocess script: {}", why);
-                std::process::exit(1);
-            });
+            .output();
 
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
+        match output_res {
+            Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            Err(why) => {
+                eprintln!("[applications] Error running preprocess script: {}", why);
+                return HandleResult::Close;
+            }
+        }
     } else {
         entry.exec.clone()
     };
@@ -75,7 +77,6 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
             Some(cmd_fmt) => cmd_fmt.replace("{}", &command),
             None => {
                 eprintln!("[applications] Error running terminal desktop entry: No terminal found");
-
                 return HandleResult::Close;
             }
         };

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -8,10 +8,10 @@ use std::{
 };
 
 #[derive(Deserialize)]
+#[serde(default)]
 pub struct Config {
     desktop_actions: bool,
     max_entries: usize,
-    #[serde(default)]
     hide_description: bool,
     terminal: Option<Terminal>,
     preprocess_exec_script: Option<PathBuf>,

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -124,7 +124,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
                             ))
                             .spawn()
                         {
-                            eprintln!("Error running desktop entry: {}", why);
+                            eprintln!("[applications] Error running desktop entry: {}", why);
                         }
                         break;
                     }
@@ -143,7 +143,7 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
             })
             .spawn()
     } {
-        eprintln!("Error running desktop entry: {}", why);
+        eprintln!("[applications] Error running desktop entry: {}", why);
     }
 
     HandleResult::Close

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -3,7 +3,11 @@ use anyrun_plugin::{anyrun_interface::HandleResult, *};
 use fuzzy_matcher::FuzzyMatcher;
 use scrubber::DesktopEntry;
 use serde::Deserialize;
-use std::{env, fs, path::PathBuf, process::Command};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -42,12 +46,9 @@ mod scrubber;
 
 #[handler]
 pub fn handler(selection: Match, state: &State) -> HandleResult {
-    let entry = state
-        .entries
-        .get(selection.id.unwrap() as usize)
-        .unwrap();
+    let entry = state.entries.get(selection.id.unwrap() as usize).unwrap();
 
-    let exec = if let Some(script) = &state.config.preprocess_exec_script {
+    let mut command = if let Some(script) = &state.config.preprocess_exec_script {
         let output = Command::new("sh")
             .arg("-c")
             .arg(format!(
@@ -68,85 +69,86 @@ pub fn handler(selection: Match, state: &State) -> HandleResult {
     };
 
     if entry.term {
-        match &state.config.terminal {
-            Some(term) => {
-                if let Err(why) = Command::new("sh")
-                    .arg("-c")
-                    .arg(format!(
-                        "{} {}",
-                        term.command,
-                        term.args.replace("{}", &exec)
-                    ))
-                    .spawn()
-                {
-                    eprintln!("[applications] Error running desktop entry: {}", why);
-                }
-            }
+        command = match make_terminal_command(&command, &state.config) {
+            Some(cmd) => cmd,
             None => {
-                let sensible_terminals = &[
-                    Terminal {
-                        command: "alacritty".to_string(),
-                        args: "-e {}".to_string(),
-                    },
-                    Terminal {
-                        command: "foot".to_string(),
-                        args: "-e \"{}\"".to_string(),
-                    },
-                    Terminal {
-                        command: "kitty".to_string(),
-                        args: "-e \"{}\"".to_string(),
-                    },
-                    Terminal {
-                        command: "wezterm".to_string(),
-                        args: "-e \"{}\"".to_string(),
-                    },
-                    Terminal {
-                        command: "wterm".to_string(),
-                        args: "-e \"{}\"".to_string(),
-                    },
-                    Terminal {
-                        command: "ghostty".to_string(),
-                        args: "-e \"{}\"".to_string(),
-                    },
-                ];
-                for term in sensible_terminals {
-                    if Command::new("which")
-                        .arg(&term.command)
-                        .output()
-                        .is_ok_and(|output| output.status.success())
-                    {
-                        if let Err(why) = Command::new("sh")
-                            .arg("-c")
-                            .arg(format!(
-                                "{} {}",
-                                term.command,
-                                term.args.replace("{}", &exec)
-                            ))
-                            .spawn()
-                        {
-                            eprintln!("[applications] Error running desktop entry: {}", why);
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-    } else if let Err(why) = {
-        let current_dir = &env::current_dir().unwrap();
+                eprintln!("[applications] Error running terminal desktop entry: No terminal found");
 
-        Command::new("sh")
-            .arg("-c")
-            .arg(&exec)
-            .current_dir(match &entry.path {
-                Some(path) if path.exists() => path,
-                _ => current_dir,
-            })
-            .spawn()
-    } {
-        eprintln!("[applications] Error running desktop entry: {}", why);
+                return HandleResult::Close;
+            }
+        };
     }
 
+    if let Err(why) = run_command(&command, entry.path.as_deref()) {
+        eprintln!("[applications] Error running desktop entry: {}", why);
+    };
+
     HandleResult::Close
+}
+
+fn run_command(command: &str, path: Option<&Path>) -> io::Result<std::process::Child> {
+    let current_dir = &env::current_dir().unwrap();
+
+    Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(match path {
+            Some(path) if path.exists() => path,
+            _ => current_dir,
+        })
+        .spawn()
+}
+
+fn make_terminal_command(command: &str, config: &Config) -> Option<String> {
+    if let Some(term) = &config.terminal {
+        return Some(format!(
+            "{} {}",
+            term.command,
+            term.args.replace("{}", command)
+        ));
+    }
+
+    let sensible_terminals = &[
+        Terminal {
+            command: "alacritty".to_string(),
+            args: "-e {}".to_string(),
+        },
+        Terminal {
+            command: "foot".to_string(),
+            args: "-e \"{}\"".to_string(),
+        },
+        Terminal {
+            command: "kitty".to_string(),
+            args: "-e \"{}\"".to_string(),
+        },
+        Terminal {
+            command: "wezterm".to_string(),
+            args: "-e \"{}\"".to_string(),
+        },
+        Terminal {
+            command: "wterm".to_string(),
+            args: "-e \"{}\"".to_string(),
+        },
+        Terminal {
+            command: "ghostty".to_string(),
+            args: "-e \"{}\"".to_string(),
+        },
+    ];
+    for term in sensible_terminals {
+        if Command::new("which")
+            .arg(&term.command)
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return Some(format!(
+                "{} {}",
+                term.command,
+                term.args.replace("{}", command)
+            ));
+        }
+    }
+
+    None
 }
 
 #[init]

--- a/plugins/applications/src/lib.rs
+++ b/plugins/applications/src/lib.rs
@@ -101,20 +101,20 @@ fn run_command(command: &str, path: Option<&Path>) -> io::Result<std::process::C
 
 const TERMINAL_COMMAND_FORMATS: &[&str] = &[
     "alacritty -e {}",
-    "foot -e \"{}\"",
-    "kitty -e \"{}\"",
-    "wezterm -e \"{}\"",
-    "wterm -e \"{}\"",
-    "ghostty -e \"{}\"",
+    "foot -- {}",
+    "kitty -- {}",
+    "wezterm start -- {}",
+    "wterm -e {}",
+    "ghostty -e {}",
+    "terminator -x {}",
+    "gnome-terminal -- {}",
+    "konsole -e {}",
+    "xterm -e {}",
 ];
 
 fn get_terminal_command_format(config: &Config) -> Option<String> {
     if let Some(term) = &config.terminal {
-        return Some(format!(
-            "{} {}",
-            term.command,
-            term.args
-        ));
+        return Some(format!("{} {}", term.command, term.args));
     }
 
     for cmd_fmt in TERMINAL_COMMAND_FORMATS {

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, env, ffi::OsStr, fs, path::PathBuf};
+use std::{
+    collections::HashMap,
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use crate::Config;
 
@@ -28,13 +34,9 @@ impl DesktopEntry {
             .unwrap_or_else(|| self.name.clone())
     }
 
-    fn from_dir_entry(
-        entry: &fs::DirEntry,
-        config: &Config,
-        lang_choices: &LangChoices,
-    ) -> Vec<Self> {
-        if entry.path().extension() == Some(OsStr::new("desktop")) {
-            let content = match fs::read_to_string(entry.path()) {
+    fn from_path(path: &Path, config: &Config, lang_choices: &LangChoices) -> Vec<Self> {
+        if path.extension() == Some(OsStr::new("desktop")) {
+            let content = match fs::read_to_string(path) {
                 Ok(content) => content,
                 Err(_) => return Vec::new(),
             };
@@ -300,7 +302,7 @@ pub fn scrubber(config: &Config) -> Result<Vec<(DesktopEntry, u64)>, Box<dyn std
             Ok(entry) => entry,
             Err(_why) => return None,
         };
-        let entries = DesktopEntry::from_dir_entry(&entry, config, &lang_choices);
+        let entries = DesktopEntry::from_path(&entry.path(), config, &lang_choices);
         Some(
             entries
                 .into_iter()
@@ -320,7 +322,7 @@ pub fn scrubber(config: &Config) -> Result<Vec<(DesktopEntry, u64)>, Box<dyn std
                         Ok(entry) => entry,
                         Err(_why) => return None,
                     };
-                    let entries = DesktopEntry::from_dir_entry(&entry, config, &lang_choices);
+                    let entries = DesktopEntry::from_path(&entry.path(), config, &lang_choices);
                     Some(
                         entries
                             .into_iter()

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -181,11 +181,16 @@ fn parse_exec(props: &HashMap<&str, &str>) -> Option<String> {
             continue;
         }
         match chars.peek() {
-            Some(&'%') | None => new_exec.push('%'),
+            Some(&'%') | None => {
+                new_exec.push('%');
+                chars.next();
+            },
 
-            Some(&next_ch) if FIELD_CODE_CHARS.contains(next_ch) => {} // Remove both `ch` and `next_ch`
-            Some(&next_ch) => {
-                new_exec.extend([ch, next_ch]);
+            Some(&next_ch) if FIELD_CODE_CHARS.contains(next_ch) => {
+                chars.next();
+            }
+            Some(_) => {
+                new_exec.push(ch);
             }
         }
     }

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -35,171 +35,139 @@ impl DesktopEntry {
     }
 
     fn from_path(path: &Path, config: &Config, lang_choices: &LangChoices) -> Vec<Self> {
-        if path.extension() == Some(OsStr::new("desktop")) {
-            let content = match fs::read_to_string(path) {
-                Ok(content) => content,
-                Err(_) => return Vec::new(),
-            };
+        if path.extension() != Some(OsStr::new("desktop")) {
+            return Vec::new();
+        }
 
-            let lines = content
-                .lines()
-                // Ignore comments
-                .filter(|line| !line.starts_with('#') && !line.is_empty())
-                .collect::<Vec<_>>();
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(_) => return Vec::new(),
+        };
 
-            let sections = lines
-                .chunk_by(|_, line| !line.starts_with('['))
-                // Remove the potential lines before the first section
-                // `section` is at least 1 element long so `section[0]` cannot panic
-                .skip_while(|section| !section[0].starts_with('['))
-                .collect::<Vec<_>>();
+        let lines = content
+            .lines()
+            // Ignore comments
+            .filter(|line| !line.starts_with('#') && !line.is_empty())
+            .collect::<Vec<_>>();
 
-            let mut ret = Vec::new();
+        let sections = lines
+            .chunk_by(|_, line| !line.starts_with('['))
+            // Remove the potential lines before the first section
+            // `section` is at least 1 element long so `section[0]` cannot panic
+            .skip_while(|section| !section[0].starts_with('['))
+            .collect::<Vec<_>>();
 
-            let entry = match sections.iter().find_map(|section| {
-                if section[0].starts_with("[Desktop Entry]") {
-                    let mut map = HashMap::new();
+        let mut ret = Vec::new();
 
-                    for line in section.iter().skip(1) {
-                        if let Some((key, val)) = line.split_once('=') {
-                            map.insert(key, val);
-                        }
-                    }
+        let Some(entry) = sections.iter().find_map(|section| {
+            if !section[0].starts_with("[Desktop Entry]") {
+                return None;
+            }
 
-                    if map.get("Type")? == &"Application"
-                        && match map.get("NoDisplay") {
-                            Some(no_display) => !no_display.parse::<bool>().unwrap_or(true),
-                            None => true,
-                        }
-                    {
-                        Some(DesktopEntry {
-                            exec: {
-                                let mut exec = map.get("Exec")?.to_string();
+            // Let's call them properties as specs call them entries but
+            // it is confusing with DesktopEntry.
+            // (see https://specifications.freedesktop.org/desktop-entry/latest/basic-format.html#entries)
+            let mut props = HashMap::new();
 
-                                for field_code in FIELD_CODE_LIST {
-                                    exec = exec.replace(field_code, "");
-                                }
-                                exec
-                            },
-                            path: map.get("Path").map(PathBuf::from),
-                            name: map.get("Name")?.to_string(),
-                            localized_name: lang_choices
-                                .localized_keys("Name")
-                                .find_map(|key| map.get(&*key))
-                                .map(ToString::to_string),
-                            keywords: map
-                                .get("Keywords")
-                                .map(|keywords| {
-                                    keywords
-                                        .split(';')
-                                        .map(|s| s.to_owned())
-                                        .collect::<Vec<_>>()
-                                })
-                                .unwrap_or_default(),
-                            localized_keywords: lang_choices
-                                .localized_keys("Keywords")
-                                .find_map(|key| map.get(&*key))
-                                .map(|keywords| {
-                                    keywords
-                                        .split(';')
-                                        .map(|s| s.to_owned())
-                                        .collect::<Vec<_>>()
-                                }),
-                            desc: lang_choices
-                                .localized_keys("Comment")
-                                .find_map(|key| map.get(&*key))
-                                .or_else(|| map.get("Comment"))
-                                .map(ToString::to_string),
-                            icon: map
-                                .get("Icon")
-                                .unwrap_or(&"application-x-executable")
-                                .to_string(),
-                            term: map
-                                .get("Terminal")
-                                .map(|val| val.to_lowercase() == "true")
-                                .unwrap_or(false),
-                            offset: 0,
-                            is_action: false,
-                        })
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }) {
-                Some(entry) => entry,
-                None => return Vec::new(),
-            };
-
-            if config.desktop_actions {
-                for (i, section) in sections.iter().enumerate() {
-                    let mut map = HashMap::new();
-
-                    for line in section.iter().skip(1) {
-                        if let Some((key, val)) = line.split_once('=') {
-                            map.insert(key, val);
-                        }
-                    }
-
-                    if section[0].starts_with("[Desktop Action") {
-                        ret.push(DesktopEntry {
-                            exec: match map.get("Exec") {
-                                Some(exec) => {
-                                    let mut exec = exec.to_string();
-
-                                    for field_code in FIELD_CODE_LIST {
-                                        exec = exec.replace(field_code, "");
-                                    }
-                                    exec
-                                }
-                                None => continue,
-                            },
-                            path: entry.path.clone(),
-                            name: match map.get("Name") {
-                                Some(name) => name.to_string(),
-                                None => continue,
-                            },
-                            localized_name: lang_choices
-                                .localized_keys("Name")
-                                .find_map(|key| map.get(&*key))
-                                .map(ToString::to_string),
-                            keywords: map
-                                .get("Keywords")
-                                .map(|keywords| {
-                                    keywords
-                                        .split(';')
-                                        .map(|s| s.to_owned())
-                                        .collect::<Vec<_>>()
-                                })
-                                .unwrap_or_default(),
-                            localized_keywords: lang_choices
-                                .localized_keys("Keywords")
-                                .find_map(|key| map.get(&*key))
-                                .map(|keywords| {
-                                    keywords
-                                        .split(';')
-                                        .map(|s| s.to_owned())
-                                        .collect::<Vec<_>>()
-                                }),
-                            desc: Some(entry.localized_name()),
-                            icon: entry.icon.clone(),
-                            term: map
-                                .get("Terminal")
-                                .map(|val| val.to_lowercase() == "true")
-                                .unwrap_or(false),
-                            offset: i as i64,
-                            is_action: true,
-                        })
-                    }
+            for line in section.iter().skip(1) {
+                if let Some((key, val)) = line.split_once('=') {
+                    props.insert(key, val);
                 }
             }
 
-            ret.push(entry);
-            ret
-        } else {
-            Vec::new()
+            if *props.get("Type")? != "Application" {
+                return None;
+            }
+
+            if props
+                .get("NoDisplay")
+                .map(|x| x.to_lowercase() == "true")
+                .unwrap_or(false)
+            {
+                return None;
+            }
+
+            DesktopEntry::from_props(&props, lang_choices, 0, false)
+        }) else {
+            // If no appropriate [Desktop Entry] section is found
+            return Vec::new();
+        };
+
+        if config.desktop_actions {
+            for (i, section) in sections.iter().enumerate() {
+                let mut action_props = HashMap::new();
+
+                for line in section.iter().skip(1) {
+                    if let Some((key, val)) = line.split_once('=') {
+                        action_props.insert(key, val);
+                    }
+                }
+
+                if section[0].starts_with("[Desktop Action") {
+                    if let Some(action_entry) =
+                        DesktopEntry::from_props(&action_props, lang_choices, i as i64, true)
+                    {
+                        ret.push(action_entry);
+                    }
+                }
+            }
         }
+
+        ret.push(entry);
+        ret
+    }
+
+    fn from_props(
+        props: &HashMap<&str, &str>,
+        lang_choices: &LangChoices,
+        offset: i64,
+        is_action: bool,
+    ) -> Option<DesktopEntry> {
+        Some(DesktopEntry {
+            exec: {
+                let mut exec = props.get("Exec")?.to_string();
+                for field_code in FIELD_CODE_LIST {
+                    exec = exec.replace(field_code, "");
+                }
+                exec
+            },
+            path: props.get("Path").map(PathBuf::from),
+            name: props.get("Name")?.to_string(),
+            localized_name: lang_choices
+                .get_localized(&props, "Name")
+                .map(ToString::to_string),
+            keywords: props
+                .get("Keywords")
+                .map(|keywords| {
+                    keywords
+                        .split(';')
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default(),
+            localized_keywords: lang_choices
+                .get_localized(&props, "Keywords")
+                .map(|keywords| {
+                    keywords
+                        .split(';')
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                }),
+            desc: lang_choices
+                .get_localized(&props, "Comment")
+                .or_else(|| props.get("Comment"))
+                .map(ToString::to_string),
+            icon: props
+                .get("Icon")
+                .unwrap_or(&"application-x-executable")
+                .to_string(),
+            term: props
+                .get("Terminal")
+                .map(|val| val.to_lowercase() == "true")
+                .unwrap_or(false),
+            offset: offset,
+            is_action: is_action,
+        })
     }
 }
 
@@ -240,6 +208,14 @@ impl<'a> LangChoices<'a> {
             .chain(self.prefix)
             .chain(self.short);
         choices.map(move |choice| format!("{key}[{choice}]"))
+    }
+
+    fn get_localized<'b>(
+        &self,
+        map: &'b HashMap<&'b str, &'b str>,
+        key: &'b str,
+    ) -> Option<&'b &'b str> {
+        self.localized_keys(key).find_map(|key| map.get(&*key))
     }
 }
 

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -8,6 +8,8 @@ use std::{
 
 use crate::Config;
 
+const DEFAULT_APPLICATION_ICON: &'static str = "application-x-executable";
+
 #[derive(Clone, Debug)]
 pub struct DesktopEntry {
     pub exec: String,
@@ -155,7 +157,7 @@ impl DesktopEntry {
             icon: icon.unwrap_or_else(|| {
                 props
                     .get("Icon")
-                    .unwrap_or(&"application-x-executable")
+                    .unwrap_or(&DEFAULT_APPLICATION_ICON)
                     .to_string()
             }),
             term: props
@@ -168,9 +170,13 @@ impl DesktopEntry {
     }
 }
 
-// Field code to remove (%f, %F, %u...) because we run the applications with no argument
+// Field codes to remove (%f, %F, %u...) because we run the applications with no argument
+// Note: %i, %c and %k could be implemented however
+// (see https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html)
 const FIELD_CODE_CHARS: &str = "fFuUdDnNickvm";
 
+// Only remove field codes, quotes and escapes will be interpreted by `sh`
+// when we run the command
 fn parse_exec(props: &HashMap<&str, &str>) -> Option<String> {
     let exec = props.get("Exec")?.to_string();
     let mut chars = exec.chars().peekable();

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -226,7 +226,7 @@ impl<'a> LangChoices<'a> {
     }
 }
 
-pub fn scrubber(config: &Config) -> Vec<(DesktopEntry, u64)> {
+pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
     let xdg_data_dirs = env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".to_owned());
 
     // Create iterator over all the files in the XDG_DATA_DIRS
@@ -267,8 +267,5 @@ pub fn scrubber(config: &Config) -> Vec<(DesktopEntry, u64)> {
         })
         .flatten();
 
-    entries
-        .enumerate()
-        .map(|(i, entry)| (entry, i as u64))
-        .collect()
+    entries.collect()
 }

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     env,
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     fs,
     path::{Path, PathBuf},
 };
@@ -269,11 +269,11 @@ pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
     // Create iterator over all the applications directories in the XDG_DATA_DIRS (and in XDG_DATA_HOME)
     // XDG compliancy is cool
     let entry_dirs = xdg_data_dirs
-        .split(':')
+        .rsplit(':')
         .chain(Some(xdg_data_home.as_str()))
         .map(|dir| format!("{}/applications/", dir));
 
-    let entries = entry_dirs
+    let entries_map: HashMap<OsString, Vec<DesktopEntry>> = entry_dirs
         // Iterate over all files in the entry_dirs
         .filter_map(|dir| match fs::read_dir(&dir) {
             Ok(files) => Some(files),
@@ -287,13 +287,12 @@ pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
         .filter_map(|entry_res| {
             let entry = entry_res.ok()?;
 
-            Some(DesktopEntry::from_path(
-                &entry.path(),
-                config,
-                &lang_choices,
+            Some((
+                entry.path().file_name()?.to_owned(),
+                DesktopEntry::from_path(&entry.path(), config, &lang_choices),
             ))
         })
-        .flatten();
+        .collect();
 
-    entries.collect()
+    entries_map.into_values().flatten().collect()
 }

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -87,7 +87,7 @@ impl DesktopEntry {
                 return None;
             }
 
-            DesktopEntry::from_props(&props, lang_choices, 0, false)
+            DesktopEntry::from_props(&props, lang_choices, None, 0, false)
         }) else {
             // If no appropriate [Desktop Entry] section is found
             return Vec::new();
@@ -104,9 +104,13 @@ impl DesktopEntry {
                 }
 
                 if section[0].starts_with("[Desktop Action") {
-                    if let Some(action_entry) =
-                        DesktopEntry::from_props(&action_props, lang_choices, i as i64, true)
-                    {
+                    if let Some(action_entry) = DesktopEntry::from_props(
+                        &action_props,
+                        lang_choices,
+                        Some(entry.icon.clone()),
+                        i as i64,
+                        true,
+                    ) {
                         ret.push(action_entry);
                     }
                 }
@@ -120,6 +124,7 @@ impl DesktopEntry {
     fn from_props(
         props: &HashMap<&str, &str>,
         lang_choices: &LangChoices,
+        icon: Option<String>,
         offset: i64,
         is_action: bool,
     ) -> Option<DesktopEntry> {
@@ -157,10 +162,12 @@ impl DesktopEntry {
                 .get_localized(&props, "Comment")
                 .or_else(|| props.get("Comment"))
                 .map(ToString::to_string),
-            icon: props
-                .get("Icon")
-                .unwrap_or(&"application-x-executable")
-                .to_string(),
+            icon: icon.unwrap_or_else(|| {
+                props
+                    .get("Icon")
+                    .unwrap_or(&"application-x-executable")
+                    .to_string()
+            }),
             term: props
                 .get("Terminal")
                 .map(|val| val.to_lowercase() == "true")

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -41,7 +41,11 @@ impl DesktopEntry {
                 Err(_) => return Vec::new(),
             };
 
-            let lines = content.lines().collect::<Vec<_>>();
+            let lines = content
+                .lines()
+                // Ignore comments
+                .filter(|line| !line.starts_with('#') && !line.is_empty())
+                .collect::<Vec<_>>();
 
             let sections = lines
                 .split_inclusive(|line| line.starts_with('['))

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -23,10 +23,6 @@ pub struct DesktopEntry {
     pub is_action: bool,
 }
 
-const FIELD_CODE_LIST: &[&str] = &[
-    "%f", "%F", "%u", "%U", "%d", "%D", "%n", "%N", "%i", "%c", "%k", "%v", "%m",
-];
-
 impl DesktopEntry {
     pub fn localized_name(&self) -> String {
         self.localized_name
@@ -129,13 +125,7 @@ impl DesktopEntry {
         is_action: bool,
     ) -> Option<DesktopEntry> {
         Some(DesktopEntry {
-            exec: {
-                let mut exec = props.get("Exec")?.to_string();
-                for field_code in FIELD_CODE_LIST {
-                    exec = exec.replace(field_code, "");
-                }
-                exec
-            },
+            exec: parse_exec(props)?,
             path: props.get("Path").map(PathBuf::from),
             name: props.get("Name")?.to_string(),
             localized_name: lang_choices
@@ -176,6 +166,31 @@ impl DesktopEntry {
             is_action: is_action,
         })
     }
+}
+
+const FIELD_CODE_CHARS: &str = "fFuUdDnNickvm";
+
+fn parse_exec(props: &HashMap<&str, &str>) -> Option<String> {
+    let exec = props.get("Exec")?.to_string();
+    let mut chars = exec.chars().peekable();
+    let mut new_exec = String::with_capacity(exec.len());
+
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            new_exec.push(ch);
+            continue;
+        }
+        match chars.peek() {
+            Some(&'%') | None => new_exec.push('%'),
+
+            Some(&next_ch) if FIELD_CODE_CHARS.contains(next_ch) => {} // Remove both `ch` and `next_ch`
+            Some(&next_ch) => {
+                new_exec.extend([ch, next_ch]);
+            }
+        }
+    }
+
+    Some(new_exec)
 }
 
 #[derive(Debug, Default)]

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -48,29 +48,15 @@ impl DesktopEntry {
                 .collect::<Vec<_>>();
 
             let sections = lines
-                .split_inclusive(|line| line.starts_with('['))
+                .chunk_by(|_, line| !line.starts_with('['))
+                // Remove the potential lines before the first section
+                // `section` is at least 1 element long so `section[0]` cannot panic
+                .skip_while(|section| !section[0].starts_with('['))
                 .collect::<Vec<_>>();
-
-            let mut line = None;
-            let mut new_sections = Vec::new();
-
-            for (i, section) in sections.iter().enumerate() {
-                if let Some(line) = line {
-                    let mut section = section.to_vec();
-                    section.insert(0, line);
-
-                    // Only pop the last redundant entry if it isn't the last item
-                    if i < sections.len() - 1 {
-                        section.pop();
-                    }
-                    new_sections.push(section);
-                }
-                line = Some(section.last().unwrap_or(&""));
-            }
 
             let mut ret = Vec::new();
 
-            let entry = match new_sections.iter().find_map(|section| {
+            let entry = match sections.iter().find_map(|section| {
                 if section[0].starts_with("[Desktop Entry]") {
                     let mut map = HashMap::new();
 
@@ -147,7 +133,7 @@ impl DesktopEntry {
             };
 
             if config.desktop_actions {
-                for (i, section) in new_sections.iter().enumerate() {
+                for (i, section) in sections.iter().enumerate() {
                     let mut map = HashMap::new();
 
                     for line in section.iter().skip(1) {

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -226,93 +226,49 @@ impl<'a> LangChoices<'a> {
     }
 }
 
-pub fn scrubber(config: &Config) -> Result<Vec<(DesktopEntry, u64)>, Box<dyn std::error::Error>> {
+pub fn scrubber(config: &Config) -> Vec<(DesktopEntry, u64)> {
+    let xdg_data_dirs = env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".to_owned());
+
     // Create iterator over all the files in the XDG_DATA_DIRS
     // XDG compliancy is cool
-    let user_path = match env::var("XDG_DATA_HOME") {
-        Ok(data_home) => {
-            format!("{}/applications/", data_home)
-        }
-        Err(_) => {
-            format!(
-                "{}/.local/share/applications/",
-                env::var("HOME").expect("Unable to determine home directory!")
-            )
-        }
-    };
+    let xdg_data_home = env::var("XDG_DATA_HOME").unwrap_or_else(|_why| {
+        format!(
+            "{}/.local/share",
+            env::var("HOME").expect("Unable to determine home directory!")
+        )
+    });
 
     let lang = env::var("LANG").ok();
     let lang_choices = LangChoices::new(lang.as_deref());
 
-    let mut entries: HashMap<String, DesktopEntry> = match env::var("XDG_DATA_DIRS") {
-        Ok(data_dirs) => {
-            // The vec for all the DirEntry objects
-            let mut paths = Vec::new();
-            // Parse the XDG_DATA_DIRS variable and list files of all the paths
-            for dir in data_dirs.split(':') {
-                match fs::read_dir(format!("{}/applications/", dir)) {
-                    Ok(dir) => {
-                        paths.extend(dir);
-                    }
-                    Err(why) => {
-                        eprintln!("[applications] Error reading directory {}: {}", dir, why);
-                    }
-                }
+    // Parse the XDG_DATA_DIRS variable and list files of all the paths
+    let entry_dirs = xdg_data_dirs
+        .split(':')
+        .chain(Some(xdg_data_home.as_str()))
+        .map(|dir| format!("{}/applications/", dir));
+
+    let entries = entry_dirs
+        .filter_map(|dir| match fs::read_dir(&dir) {
+            Ok(files) => Some(files),
+            Err(why) => {
+                eprintln!("[applications] Error reading directory {}: {}", dir, why);
+                None
             }
-            // Make sure the list of paths isn't empty
-            if paths.is_empty() {
-                return Err("No valid desktop file dirs found!".into());
-            }
+        })
+        .flatten()
+        .filter_map(|entry_res| {
+            let entry = entry_res.ok()?;
 
-            // Return it
-            paths
-        }
-        Err(_) => fs::read_dir("/usr/share/applications")?.collect(),
-    }
-    .into_iter()
-    .filter_map(|entry| {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(_why) => return None,
-        };
-        let entries = DesktopEntry::from_path(&entry.path(), config, &lang_choices);
-        Some(
-            entries
-                .into_iter()
-                .map(|entry| (format!("{}{}", entry.name, entry.icon), entry)),
-        )
-    })
-    .flatten()
-    .collect();
+            Some(DesktopEntry::from_path(
+                &entry.path(),
+                config,
+                &lang_choices,
+            ))
+        })
+        .flatten();
 
-    // Go through user directory desktop files for overrides
-    match fs::read_dir(&user_path) {
-        Ok(dir_entries) => entries.extend(
-            dir_entries
-                .into_iter()
-                .filter_map(|entry| {
-                    let entry = match entry {
-                        Ok(entry) => entry,
-                        Err(_why) => return None,
-                    };
-                    let entries = DesktopEntry::from_path(&entry.path(), config, &lang_choices);
-                    Some(
-                        entries
-                            .into_iter()
-                            .map(|entry| (format!("{}{}", entry.name, entry.icon), entry)),
-                    )
-                })
-                .flatten(),
-        ),
-        Err(why) => eprintln!(
-            "[applications] Error reading directory {}: {}",
-            user_path, why
-        ),
-    }
-
-    Ok(entries
-        .into_iter()
+    entries
         .enumerate()
-        .map(|(i, (_, entry))| (entry, i as u64))
-        .collect())
+        .map(|(i, entry)| (entry, i as u64))
+        .collect()
 }

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -129,7 +129,7 @@ impl DesktopEntry {
             path: props.get("Path").map(PathBuf::from),
             name: props.get("Name")?.to_string(),
             localized_name: lang_choices
-                .get_localized(&props, "Name")
+                .get_localized(props, "Name")
                 .map(ToString::to_string),
             keywords: props
                 .get("Keywords")
@@ -141,7 +141,7 @@ impl DesktopEntry {
                 })
                 .unwrap_or_default(),
             localized_keywords: lang_choices
-                .get_localized(&props, "Keywords")
+                .get_localized(props, "Keywords")
                 .map(|keywords| {
                     keywords
                         .split(';')
@@ -149,7 +149,7 @@ impl DesktopEntry {
                         .collect::<Vec<_>>()
                 }),
             desc: lang_choices
-                .get_localized(&props, "Comment")
+                .get_localized(props, "Comment")
                 .or_else(|| props.get("Comment"))
                 .map(ToString::to_string),
             icon: icon.unwrap_or_else(|| {
@@ -162,8 +162,8 @@ impl DesktopEntry {
                 .get("Terminal")
                 .map(|val| val.to_lowercase() == "true")
                 .unwrap_or(false),
-            offset: offset,
-            is_action: is_action,
+            offset,
+            is_action,
         })
     }
 }

--- a/plugins/applications/src/scrubber.rs
+++ b/plugins/applications/src/scrubber.rs
@@ -168,6 +168,7 @@ impl DesktopEntry {
     }
 }
 
+// Field code to remove (%f, %F, %u...) because we run the applications with no argument
 const FIELD_CODE_CHARS: &str = "fFuUdDnNickvm";
 
 fn parse_exec(props: &HashMap<&str, &str>) -> Option<String> {
@@ -184,7 +185,7 @@ fn parse_exec(props: &HashMap<&str, &str>) -> Option<String> {
             Some(&'%') | None => {
                 new_exec.push('%');
                 chars.next();
-            },
+            }
 
             Some(&next_ch) if FIELD_CODE_CHARS.contains(next_ch) => {
                 chars.next();
@@ -249,8 +250,6 @@ impl<'a> LangChoices<'a> {
 pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
     let xdg_data_dirs = env::var("XDG_DATA_DIRS").unwrap_or("/usr/share".to_owned());
 
-    // Create iterator over all the files in the XDG_DATA_DIRS
-    // XDG compliancy is cool
     let xdg_data_home = env::var("XDG_DATA_HOME").unwrap_or_else(|_why| {
         format!(
             "{}/.local/share",
@@ -261,13 +260,15 @@ pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
     let lang = env::var("LANG").ok();
     let lang_choices = LangChoices::new(lang.as_deref());
 
-    // Parse the XDG_DATA_DIRS variable and list files of all the paths
+    // Create iterator over all the applications directories in the XDG_DATA_DIRS (and in XDG_DATA_HOME)
+    // XDG compliancy is cool
     let entry_dirs = xdg_data_dirs
         .split(':')
         .chain(Some(xdg_data_home.as_str()))
         .map(|dir| format!("{}/applications/", dir));
 
     let entries = entry_dirs
+        // Iterate over all files in the entry_dirs
         .filter_map(|dir| match fs::read_dir(&dir) {
             Ok(files) => Some(files),
             Err(why) => {
@@ -276,6 +277,7 @@ pub fn scrubber(config: &Config) -> Vec<DesktopEntry> {
             }
         })
         .flatten()
+        // Parse these files with DesktopEntry::from_path(), ignoring errors from ReadDir
         .filter_map(|entry_res| {
             let entry = entry_res.ok()?;
 


### PR DESCRIPTION
- Code simplification: remove some useless code repetitions, make some parts shorter, more optimized and, in my opinion, easier to read and understand
- Fix multiple terminal commands (for `Terminal=true` desktop entries)
- Add default support for some major terminal emulators (xterm, konsole, gnome-terminal and terminator)
- Add a `prioritize_actions` config option to allow user choosing whether to prioritize actions or not (could not be disabled before)
- Minor fixes for coherency
  - ensure there is an `[applications]` prefix before all stderr messages (some of them had it, some didn't)
  - avoid calling `std::process::exit()` for some errors and not others with no reasons
  - don't discard the `preprocess_exec_script` stderr output
- handle `.desktop` files comments
- support `%%` in the `Exec=` property of `.desktop` files
- Add `#[serde(default)]` to the whole `struct Config` in order to allow partial config files

It is my first pull request by the way, so please tell me if I do something wrong.